### PR TITLE
New lepton selections implementation

### DIFF
--- a/Utilities/BranchReader.cc
+++ b/Utilities/BranchReader.cc
@@ -71,6 +71,7 @@ public:
   // Int_t           Muon_genPartIdx[18];   //[nMuon]
   Int_t           Muon_tightId[18];   //[nMuon]
   Bool_t          Muon_looseId[18];   //[nMuon]
+  UChar_t	  Muon_highPtId[18];  //[nMuon]
   Float_t         Muon_pfRelIso04_all[18];   //[nMuon]
 
   //MET
@@ -162,6 +163,7 @@ public:
     chain->SetBranchAddress("Muon_charge", &Muon_charge);
     chain->SetBranchAddress("Muon_looseId", &Muon_looseId);
     chain->SetBranchAddress("Muon_tightId", &Muon_tightId);
+    chain->SetBranchAddress("Muon_highPtId", &Muon_highPtId);
     chain->SetBranchAddress("Muon_pfRelIso04_all", &Muon_pfRelIso04_all);
 
     chain->SetBranchAddress("MET_phi", &MET_phi);

--- a/Utilities/Configs.cc
+++ b/Utilities/Configs.cc
@@ -4,6 +4,7 @@
 #include <vector>
 #include <map>
 #include <string>
+#include <iostream>
 
 #include "TString.h"
 

--- a/Utilities/DataFormat.cc
+++ b/Utilities/DataFormat.cc
@@ -71,6 +71,9 @@ BTag* Jet::btagger = nullptr;
 struct Lepton : PO {
   Lepton(TLorentzVector v_ = TLorentzVector()) : PO(v_) {};
   int charge;
+  bool IsPrimary;
+  bool IsLoose;
+  bool IsVeto;
   // float jetRelIso;
   // int pdgId;
   // int jetIdx;
@@ -80,15 +83,15 @@ struct Lepton : PO {
 
 struct Electron : Lepton {
   Electron(TLorentzVector v_ = TLorentzVector()) : Lepton(v_) {};
-  int cutBased;
-  bool cutBasedHEEP;
+  //int cutBased;
+  //bool cutBasedHEEP;
 };
 
 struct Muon: Lepton {
   Muon(TLorentzVector v_ = TLorentzVector()) :Lepton(v_) {};
-  int tightId;
-  int looseId;
-  double relIso;
+  //int tightId;
+  //int looseId;
+  //double relIso;
 };
 
 struct MET : PO {

--- a/Utilities/NanoAODReader.cc
+++ b/Utilities/NanoAODReader.cc
@@ -212,6 +212,8 @@ public:
       tmp.IsLoose = passLoose;
       tmp.IsVeto = passVeto;
 
+      if(!passVeto && !passLoose && !passPrimary) continue;
+
       Electrons.push_back(tmp);
       Leptons.push_back(tmp);
     }
@@ -237,6 +239,8 @@ public:
       tmp.IsPrimary = passPrimary;
       tmp.IsLoose = passLoose;
       tmp.IsVeto = passVeto;
+
+      if(!passVeto && !passLoose && !passPrimary) continue;
 
       Muons.push_back(tmp);
       Leptons.push_back(tmp);


### PR DESCRIPTION
Implemented all three types of lepton selections: Primary, loose, veto.
This meant including the muon highPtId, which is of a weird type (UChar_t), so whether this works might need testing. Moreover, the branch might not yet exist in the skims. If that is the case, we should move to the tightId for the moment, instead.
Tested for compilability which pointed out a missing include in a dependent file.

This covers issues #5 and #6 