### PR TITLE
Cross cleaning between jets and leptons

### DIFF
--- a/Utilities/DataFormat.cc
+++ b/Utilities/DataFormat.cc
@@ -59,6 +59,7 @@ struct Lepton : PO {
   bool IsPrimary;
   bool IsLoose;
   bool IsVeto;
+  vector<bool> OverlapsJet; //{PUID: loose, medium, tight}
   // float jetRelIso;
   // int pdgId;
   // int jetIdx;

--- a/Utilities/NanoAODReader.cc
+++ b/Utilities/NanoAODReader.cc
@@ -82,6 +82,13 @@ public:
     return chain->GetEntries();
   }
 
+  //function to determine lepton-jet overlaps, gives answer depending on PUID passing or not
+  vector<bool> OverlapCheck(Lepton ell_){
+    vector<bool> out = {true, true, true};
+    for(unsigned j = 0; j < Jets.size(); ++j) if(fabs(Jets[j].DeltaR(ell_)) < 0.4) out = Jets[j].PUIDpasses;//this solution presumes there is only 1 possible jet to match
+   return out;
+  }
+
   void ReadEvent(Long64_t i) {
     evts->GetEntry(i);
     run = evts->run;
@@ -189,6 +196,9 @@ public:
 
       if(!passVeto && !passLoose && !passPrimary) continue;
 
+      //check for jet overlaps
+      tmp.OverlapsJet = OverlapCheck(tmp);
+
       Electrons.push_back(tmp);
       Leptons.push_back(tmp);
     }
@@ -216,6 +226,9 @@ public:
       tmp.IsVeto = passVeto;
 
       if(!passVeto && !passLoose && !passPrimary) continue;
+
+      //check for jet overlaps
+      tmp.OverlapsJet = OverlapCheck(tmp);
 
       Muons.push_back(tmp);
       Leptons.push_back(tmp);


### PR DESCRIPTION
This PR introduces cross-cleaning between jets and leptons, allowing later treatment of overlaps to occur in the final analyzer code by a vector of three bools pertaining to the three PUID working points. Depending on what is chosen, or none is, leptons can be ignored or treated as jets accordingly.
The implemented solution assumes there is a unique jet within 0.4 which should cover 99% of cases. It can be possible that a lepton falls between two jets and is within the radius of both, but assigned to one. This is a complication I do not think we need to take care of... If we treat jets PU-ID independently for this purpose, it becomes moot, anyways.

For #13 