### PR TITLE
Adding L1Prefire weights and breaking event weight calculations to introduce variations

### DIFF
--- a/Utilities/BranchReader.cc
+++ b/Utilities/BranchReader.cc
@@ -117,6 +117,11 @@ public:
   bool Flag_eeBadScFilter;
   bool Flag_ecalBadCalibFilter;
 
+  // L1PreFiring weights for 2016 and 2017
+  Float_t L1PreFiringWeight_Nom;
+  Float_t L1PreFiringWeight_Up;
+  Float_t L1PreFiringWeight_Down;
+
 
   Events(TChain *chain_, string sy_, bool mc_){
      chain = chain_;
@@ -231,6 +236,12 @@ public:
       isolated_muon_track_trigger = false;
       chain->SetBranchAddress("Flag_eeBadScFilter", &Flag_eeBadScFilter);
       chain->SetBranchAddress("Flag_ecalBadCalibFilter", &Flag_ecalBadCalibFilter);
+    }
+
+    if(SampleYear == "2016" || SampleYear == "2016apv" || SampleYear == "2017"){
+      chain->SetBranchAddress("L1PreFiringWeight_Nom", &L1PreFiringWeight_Nom);
+      chain->SetBranchAddress("L1PreFiringWeight_Up", &L1PreFiringWeight_Up);
+      chain->SetBranchAddress("L1PreFiringWeight_Down", &L1PreFiringWeight_Down);
     }
 
     chain->SetBranchAddress("PV_npvs", &PV_npvs);

--- a/Utilities/DataFormat.cc
+++ b/Utilities/DataFormat.cc
@@ -87,5 +87,10 @@ struct GenMET : PO {
   GenMET(TLorentzVector v_ = TLorentzVector()) : PO(v_) {};
 };
 
+struct EventWeight{
+  string source;
+  bool IsActive;
+  float variations[3];
+};
 
 #endif


### PR DESCRIPTION
Breaking change to how event weights are calculated from scale factors.
Output should in the end be a vector of weights, starting with the nominal, followed up with a labeled set of up and down variations of the various sources.