### PR TITLE
Pushing event weight calculations from SFs into NanoAODReader

### DIFF
--- a/Utilities/BranchReader.cc
+++ b/Utilities/BranchReader.cc
@@ -293,7 +293,30 @@ public:
       chain->SetBranchAddress("Pileup_sumEOOT", &Pileup_sumEOOT);
       chain->SetBranchAddress("Pileup_sumLOOT", &Pileup_sumLOOT);
 
-      
+      chain->SetBranchAddress("Electron_scaleFactor", &Electron_scaleFactor);
+      chain->SetBranchAddress("Electron_scaleFactorUp", &Electron_scaleFactorUp);
+      chain->SetBranchAddress("Electron_scaleFactorDown", &Electron_scaleFactorDown);
+      chain->SetBranchAddress("Muon_scaleFactor", &Muon_scaleFactor);
+      chain->SetBranchAddress("Muon_scaleFactorSyst", &Muon_scaleFactorSyst);
+      chain->SetBranchAddress("Muon_scaleFactorStat", &Muon_scaleFactorStat);
+      chain->SetBranchAddress("Jet_bTagScaleFactorTight", &Jet_bTagScaleFactorTight);
+      chain->SetBranchAddress("Jet_bTagScaleFactorTightUp", &Jet_bTagScaleFactorTightUp);
+      chain->SetBranchAddress("Jet_bTagScaleFactorTightDown", &Jet_bTagScaleFactorTightDown);
+      chain->SetBranchAddress("Jet_bTagScaleFactorMedium", &Jet_bTagScaleFactorMedium);
+      chain->SetBranchAddress("Jet_bTagScaleFactorMediumUp", &Jet_bTagScaleFactorMediumUp);
+      chain->SetBranchAddress("Jet_bTagScaleFactorMediumDown", &Jet_bTagScaleFactorMediumDown);
+      chain->SetBranchAddress("Jet_bTagScaleFactorLoose", &Jet_bTagScaleFactorLoose);
+      chain->SetBranchAddress("Jet_bTagScaleFactorLooseUp", &Jet_bTagScaleFactorLooseUp);
+      chain->SetBranchAddress("Jet_bTagScaleFactorLooseDown", &Jet_bTagScaleFactorLooseDown);
+      chain->SetBranchAddress("Jet_puIdScaleFactorTight", &Jet_puIdScaleFactorTight);
+      chain->SetBranchAddress("Jet_puIdScaleFactorTightUp", &Jet_puIdScaleFactorTightUp);
+      chain->SetBranchAddress("Jet_puIdScaleFactorTightDown", &Jet_puIdScaleFactorTightDown);
+      chain->SetBranchAddress("Jet_puIdScaleFactorMedium", &Jet_puIdScaleFactorMedium);
+      chain->SetBranchAddress("Jet_puIdScaleFactorMediumUp", &Jet_puIdScaleFactorMediumUp);
+      chain->SetBranchAddress("Jet_puIdScaleFactorMediumDown", &Jet_puIdScaleFactorMediumDown);
+      chain->SetBranchAddress("Jet_puIdScaleFactorLoose", &Jet_puIdScaleFactorLoose);
+      chain->SetBranchAddress("Jet_puIdScaleFactorLooseUp", &Jet_puIdScaleFactorLooseUp);
+      chain->SetBranchAddress("Jet_puIdScaleFactorLooseDown", &Jet_puIdScaleFactorLooseDown);
     }
 
     if (SampleYear == "2016" || SampleYear == "2016apv"){

--- a/Utilities/BranchReader.cc
+++ b/Utilities/BranchReader.cc
@@ -59,6 +59,8 @@ public:
   Float_t         Jet_mass_jesTotalDown[25];   //[nJet]
   Float_t         Jet_mass_jerUp[25];   //[nJet]
   Float_t         Jet_mass_jerDown[25];   //[nJet]
+  Float_t	  Jet_bRegCorr[25];   //[nJet]
+  Float_t	  Jet_bRegRes[25];  //[nJet]
 
   // Electron
   UInt_t          nElectron;
@@ -112,6 +114,32 @@ public:
   Float_t         TrigObj_eta[49];   //[nTrigObj]
   Float_t         TrigObj_phi[49];   //[nTrigObj]
   Int_t           TrigObj_id[49];   //[nTrigObj]
+
+  //SFs
+  Float_t	  Electron_scaleFactor[9]; //nElectron
+  Float_t	  Electron_scaleFactorUp[9]; //[nElectron]
+  Float_t	  Electron_scaleFactorDown[9]; //[nElectron]
+  Float_t	  Muon_scaleFactor[18]; //[nMuon]
+  Float_t	  Muon_scaleFactorSyst[18]; //[nMuon]
+  Float_t	  Muon_scaleFactorStat[18]; //[nMuon]
+  Float_t	  Jet_bTagScaleFactorTight[25]; //[nJet]
+  Float_t	  Jet_bTagScaleFactorTightUp[25]; //[nJet]
+  Float_t	  Jet_bTagScaleFactorTightDown[25]; //[nJet]
+  Float_t         Jet_bTagScaleFactorMedium[25]; //[nJet]
+  Float_t         Jet_bTagScaleFactorMediumUp[25]; //[nJet]
+  Float_t         Jet_bTagScaleFactorMediumDown[25]; //[nJet]
+  Float_t         Jet_bTagScaleFactorLoose[25]; //[nJet]
+  Float_t         Jet_bTagScaleFactorLooseUp[25]; //[nJet]
+  Float_t         Jet_bTagScaleFactorLooseDown[25]; //[nJet]
+  Float_t	  Jet_puIdScaleFactorTight[25]; //[nJet]
+  Float_t	  Jet_puIdScaleFactorTightUp[25]; //nJet]
+  Float_t	  Jet_puIdScaleFactorTightDown[25]; //[nJet]
+  Float_t         Jet_puIdScaleFactorMedium[25]; //[nJet]
+  Float_t         Jet_puIdScaleFactorMediumUp[25]; //nJet]
+  Float_t         Jet_puIdScaleFactorMediumDown[25]; //[nJet]
+  Float_t         Jet_puIdScaleFactorLoose[25]; //[nJet]
+  Float_t         Jet_puIdScaleFactorLooseUp[25]; //nJet]
+  Float_t         Jet_puIdScaleFactorLooseDown[25]; //[nJet]
 
   //Trigger
   bool isolated_electron_trigger;
@@ -174,6 +202,10 @@ public:
     chain->SetBranchAddress("Jet_jetId", &Jet_jetId);
     chain->SetBranchAddress("Jet_puId", &Jet_puId);
     chain->SetBranchAddress("Jet_btagDeepFlavB", &Jet_btagDeepFlavB);
+    chain->SetBranchAddress("Jet_bRegCorr", &Jet_bRegCorr);
+    chain->SetBranchAddress("Jet_bRegRes", &Jet_bRegRes);
+    chain->SetBranchAddress("Jet_pt_nom", &Jet_pt_nom);
+    chain->SetBranchAddress("Jet_mass_nom", &Jet_mass_nom);
 
     chain->SetBranchAddress("nElectron", &nElectron);
     chain->SetBranchAddress("Electron_pt", &Electron_pt);
@@ -197,6 +229,8 @@ public:
 
     chain->SetBranchAddress("MET_phi", &MET_phi);
     chain->SetBranchAddress("MET_pt", &MET_pt);
+    chain->SetBranchAddress("MET_T1_pt", &MET_T1_pt);
+    chain->SetBranchAddress("MET_T1_phi", &MET_T1_phi);
 
     chain->SetBranchAddress("nTrigObj", &nTrigObj);
     chain->SetBranchAddress("TrigObj_pt", &TrigObj_pt);
@@ -208,6 +242,15 @@ public:
     chain->SetBranchAddress("luminosityBlock", &luminosityBlock);
 
     if (IsMC){
+      chain->SetBranchAddress("Jet_pt_jesTotalUp", &Jet_pt_jesTotalUp);
+      chain->SetBranchAddress("Jet_pt_jesTotalDown", &Jet_pt_jesTotalDown);
+      chain->SetBranchAddress("Jet_pt_jerUp", &Jet_pt_jerUp);
+      chain->SetBranchAddress("Jet_pt_jerDown", &Jet_pt_jerDown);
+      chain->SetBranchAddress("Jet_mass_jesTotalUp", &Jet_mass_jesTotalUp);
+      chain->SetBranchAddress("Jet_mass_jesTotalDown", &Jet_mass_jesTotalDown);
+      chain->SetBranchAddress("Jet_mass_jerUp", &Jet_mass_jerUp);
+      chain->SetBranchAddress("Jet_mass_jerDown", &Jet_mass_jerDown);
+
       chain->SetBranchAddress("Jet_hadronFlavour", &Jet_hadronFlavour);
       chain->SetBranchAddress("Jet_partonFlavour", &Jet_partonFlavour);
       chain->SetBranchAddress("Jet_genJetIdx", &Jet_genJetIdx);
@@ -219,6 +262,17 @@ public:
       chain->SetBranchAddress("GenJet_mass", &GenJet_mass);
       chain->SetBranchAddress("GenJet_hadronFlavour", &GenJet_hadronFlavour);
       chain->SetBranchAddress("GenJet_partonFlavour", &GenJet_partonFlavour);
+
+      chain->SetBranchAddress("MET_T1smear_pt", &MET_T1smear_pt);
+      chain->SetBranchAddress("MET_T1smear_phi", &MET_T1smear_phi);
+      chain->SetBranchAddress("MET_T1smear_pt_jesTotalUp", &MET_T1smear_pt_jesTotalUp);
+      chain->SetBranchAddress("MET_T1smear_phi_jesTotalUp", &MET_T1smear_phi_jesTotalUp);
+      chain->SetBranchAddress("MET_T1smear_pt_jesTotalDown", &MET_T1smear_pt_jesTotalDown);
+      chain->SetBranchAddress("MET_T1smear_phi_jesTotalDown", &MET_T1smear_phi_jesTotalDown);
+      chain->SetBranchAddress("MET_T1smear_pt_jerUp", &MET_T1smear_pt_jerUp);
+      chain->SetBranchAddress("MET_T1smear_phi_jerUp", &MET_T1smear_phi_jerUp);
+      chain->SetBranchAddress("MET_T1smear_pt_jerDown", &MET_T1smear_pt_jerDown);
+      chain->SetBranchAddress("MET_T1smear_phi_jerDown", &MET_T1smear_phi_jerDown);
 
       chain->SetBranchAddress("GenMET_phi", &GenMET_phi);
       chain->SetBranchAddress("GenMET_pt", &GenMET_pt);
@@ -238,6 +292,8 @@ public:
       chain->SetBranchAddress("Pileup_pudensity", &Pileup_pudensity);
       chain->SetBranchAddress("Pileup_sumEOOT", &Pileup_sumEOOT);
       chain->SetBranchAddress("Pileup_sumLOOT", &Pileup_sumLOOT);
+
+      
     }
 
     if (SampleYear == "2016" || SampleYear == "2016apv"){

--- a/Utilities/DataFormat.cc
+++ b/Utilities/DataFormat.cc
@@ -65,6 +65,7 @@ struct Lepton : PO {
   bool IsLoose;
   bool IsVeto;
   vector<bool> OverlapsJet; //{PUID: loose, medium, tight}
+  vector<float> SFs;
   // float jetRelIso;
   // int pdgId;
   // int jetIdx;

--- a/Utilities/DataFormat.cc
+++ b/Utilities/DataFormat.cc
@@ -98,8 +98,7 @@ struct GenMET : PO {
 
 struct EventWeight{
   string source;
-  bool IsActive;
-  float variations[3];
+  vector<float> variations;
 };
 
 struct RegionID{

--- a/Utilities/DataFormat.cc
+++ b/Utilities/DataFormat.cc
@@ -48,10 +48,13 @@ struct Jet : PO {
   Jet(TLorentzVector v_ = TLorentzVector()) : PO(v_) {};
   TLorentzVector JESup, JESdown, JERup, JERdown;
   vector<bool> PUIDpasses; // {loose, medium, tight}
+  vector<vector<float> > PUIDSFweights; // {nominal, up, down} x {loose, medium, tight}
+  
   int genJetIdx;
   int hadronFlavour;
   int partonFlavour;
   vector<bool> bTagPasses; // {loose, medium, tight}
+  vector<vector<float> > bJetSFweights; // {nominal, up, down} x {loose, medium, tight}
 };
 
 struct Lepton : PO {

--- a/Utilities/NanoAODReader.cc
+++ b/Utilities/NanoAODReader.cc
@@ -178,6 +178,26 @@ public:
       //set PUID flags
       tmp.PUIDpasses = PUID(tmp.Pt(), fabs(tmp.Eta()), evts->Jet_puId[i], evts->SampleYear);
 
+      //set PUID SFs
+      if(!evts->IsMC || evts->Jet_pt_nom[i] >= 50. || evts->Jet_genJetIdx[i] < 0) tmp.PUIDSFweights = {{1.,1.,1.}, {1.,1.,1.}, {1.,1.,1.}}; //unlike other SFs, PU Jets and jets failing ID are not supposed to contribute to event weights
+      else{
+	if(tmp.PUIDpasses[0]){
+	  tmp.PUIDSFweights[0][0] = evts->Jet_puIdScaleFactorLoose[i];
+	  tmp.PUIDSFweights[1][0] = evts->Jet_puIdScaleFactorLooseUp[i];
+	  tmp.PUIDSFweights[2][0] = evts->Jet_puIdScaleFactorLooseDown[i];
+	}
+	if(tmp.PUIDpasses[1]){
+          tmp.PUIDSFweights[0][1] = evts->Jet_puIdScaleFactorMedium[i];
+          tmp.PUIDSFweights[1][1] = evts->Jet_puIdScaleFactorMediumUp[i];
+          tmp.PUIDSFweights[2][1] = evts->Jet_puIdScaleFactorMediumDown[i];
+        }
+        if(tmp.PUIDpasses[2]){
+          tmp.PUIDSFweights[0][2] = evts->Jet_puIdScaleFactorTight[i];
+          tmp.PUIDSFweights[1][2] = evts->Jet_puIdScaleFactorTightUp[i];
+          tmp.PUIDSFweights[2][2] = evts->Jet_puIdScaleFactorTightDown[i];
+        }
+      }
+
       //set generator information
       if (IsMC) {
         tmp.genJetIdx = evts->Jet_genJetIdx[i];
@@ -188,7 +208,45 @@ public:
       //set btagging flags
       tmp.bTagPasses = bTag(evts->Jet_btagDeepFlavB[i], evts->SampleYear);
 
+      //set btagging SFs
+      if(!evts->IsMC) tmp.bJetSFweights = {{1.,1.,1.}, {1.,1.,1.}, {1.,1.,1.}};
+      else{
+	//FIXME: Need b-tagging efficiency per sample at some point, see https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagSFMethods#b_tagging_efficiency_in_MC_sampl
+	float bTagEff[3] = {.9, .7, .5};
+	if(tmp.bTagPasses[0]){
+	  tmp.bJetSFweights[0][0] = evts->Jet_bTagScaleFactorLoose[i];
+          tmp.bJetSFweights[1][0] = evts->Jet_bTagScaleFactorLooseUp[i];
+          tmp.bJetSFweights[2][0] = evts->Jet_bTagScaleFactorLooseDown[i];
+	}
+	else{
+	  tmp.bJetSFweights[0][0] = (1. - bTagEff[0] * evts->Jet_bTagScaleFactorLoose[i]) / (1. - bTagEff[0]);
+          tmp.bJetSFweights[1][0] = (1. - bTagEff[0] * evts->Jet_bTagScaleFactorLooseUp[i]) / (1. - bTagEff[0]);
+          tmp.bJetSFweights[2][0] = (1. - bTagEff[0] * evts->Jet_bTagScaleFactorLooseDown[i]) / (1. - bTagEff[0]);
+	}
+        if(tmp.bTagPasses[1]){
+          tmp.bJetSFweights[0][1] = evts->Jet_bTagScaleFactorMedium[i];
+          tmp.bJetSFweights[1][1] = evts->Jet_bTagScaleFactorMediumUp[i];
+          tmp.bJetSFweights[2][1] = evts->Jet_bTagScaleFactorMediumDown[i];
+        }
+        else{
+          tmp.bJetSFweights[0][1] = (1. - bTagEff[1] * evts->Jet_bTagScaleFactorMedium[i]) / (1. - bTagEff[1]);
+          tmp.bJetSFweights[1][1] = (1. - bTagEff[1] * evts->Jet_bTagScaleFactorMediumUp[i]) / (1. - bTagEff[1]);
+          tmp.bJetSFweights[2][1] = (1. - bTagEff[1] * evts->Jet_bTagScaleFactorMediumDown[i]) / (1. - bTagEff[1]);
+        }
+        if(tmp.bTagPasses[2]){
+          tmp.bJetSFweights[0][2] = evts->Jet_bTagScaleFactorTight[i];
+          tmp.bJetSFweights[1][2] = evts->Jet_bTagScaleFactorTightUp[i];
+          tmp.bJetSFweights[2][2] = evts->Jet_bTagScaleFactorTightDown[i];
+        }
+        else{
+          tmp.bJetSFweights[0][2] = (1. - bTagEff[2] * evts->Jet_bTagScaleFactorTight[i]) / (1. - bTagEff[2]);
+          tmp.bJetSFweights[1][2] = (1. - bTagEff[2] * evts->Jet_bTagScaleFactorTightUp[i]) / (1. - bTagEff[2]);
+          tmp.bJetSFweights[2][2] = (1. - bTagEff[2] * evts->Jet_bTagScaleFactorTightDown[i]) / (1. - bTagEff[2]);
+        }
+      }
+
       Jets.push_back(tmp);
+
     }
   }
 

--- a/Utilities/NanoAODReader.cc
+++ b/Utilities/NanoAODReader.cc
@@ -296,6 +296,14 @@ public:
       //check for jet overlaps
       tmp.OverlapsJet = OverlapCheck(tmp);
 
+      //set SF and variation for primary only
+      if(passPrimary && evts->IsMC){
+	tmp.SFs[0] = evts->Electron_scaleFactor[i];
+	tmp.SFs[1] = evts->Electron_scaleFactorUp[i];
+	tmp.SFs[2] = evts->Electron_scaleFactorDown[i];
+      }
+      else tmp.SFs = {1., 1., 1.};
+
       Electrons.push_back(tmp);
       Leptons.push_back(tmp);
     }
@@ -335,10 +343,18 @@ public:
       //check for jet overlaps
       tmp.OverlapsJet = OverlapCheck(tmp);
 
+      //set SF and variation for primary only
+      if(passPrimary && evts->IsMC){
+        tmp.SFs[0] = evts->Muon_scaleFactor[i];
+        tmp.SFs[1] = evts->Muon_scaleFactor[i] + sqrt( pow(evts->Muon_scaleFactorStat[i],2) + pow(evts->Muon_scaleFactorSyst[i],2) );
+        tmp.SFs[2] = evts->Muon_scaleFactor[i] + sqrt( pow(evts->Muon_scaleFactorStat[i],2) + pow(evts->Muon_scaleFactorSyst[i],2) );
+      }
+      else tmp.SFs = {1., 1., 1.};
+
       Muons.push_back(tmp);
       Leptons.push_back(tmp);
     }
-  }
+  } 
 
   void ReadMET() {
     Met = TLorentzVector();

--- a/Utilities/NanoAODReader.cc
+++ b/Utilities/NanoAODReader.cc
@@ -35,6 +35,7 @@ public:
 
     if (conf->iFile >= 0) { // batch mode
       vector<string> rootfiles = GetFileNames();
+      rootfiles = {"/afs/cern.ch/user/d/doverton/public/0112A6B8-1FF9-CA49-BD91-1CBDB31507DB.root"}; //FIXME: Hacked with new format file for testing
       for (string rf : rootfiles) {
         chain->Add(TString(rf));
         cout << "Successfully loaded root file: " << rf << endl;

--- a/Utilities/NanoAODReader.cc
+++ b/Utilities/NanoAODReader.cc
@@ -302,11 +302,55 @@ public:
       //check for jet overlaps
       tmp.OverlapsJet = OverlapCheck(tmp);
 
-      //set SF and variation for primary only
+      //set SF and variation for primary only, HEEP as in https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammaRunIIRecommendations#HEEPV7_0
       if(passPrimary && evts->IsMC){
-	tmp.SFs[0] = evts->Electron_scaleFactor[i];
-	tmp.SFs[1] = evts->Electron_scaleFactorUp[i];
-	tmp.SFs[2] = evts->Electron_scaleFactorDown[i];
+        TString sampleyear;
+        string sy = conf->SampleYear;
+        if (sy == "16apv" || sy == "2016apv") sampleyear = "2016";
+        else if (sy == "16" || sy == "2016") sampleyear = "2016";
+        else if (sy == "17" || sy == "2017") sampleyear = "2017";
+        else if (sy == "18" || sy == "2018") sampleyear = "2018";
+
+        if(absEta < 1.4442){
+	  if(sampleyear == "2016"){
+	    tmp.SFs[0] = 0.983;
+	    float unc = tmp.Et() < 90 ? 0.01 : min(1 + (tmp.Et() - 90) * 0.0022, 0.03);
+            tmp.SFs[1] = 0.983 + unc;
+            tmp.SFs[2] = 0.983 - unc;
+	  }
+	  else if(sampleyear == "2017"){
+	    tmp.SFs[0] = 0.968;
+            float unc = tmp.Et() < 90 ? 0.01 : min(1 + (tmp.Et() - 90) * 0.0022, 0.03);
+            tmp.SFs[1] = 0.968 + unc;
+            tmp.SFs[2] = 0.968 - unc;
+	  }
+	  else if(sampleyear == "2018"){
+	    tmp.SFs[0] = 0.969;
+            float unc = tmp.Et() < 90 ? 0.01 : min(1 + (tmp.Et() - 90) * 0.0022, 0.03);
+            tmp.SFs[1] = 0.969 + unc;
+            tmp.SFs[2] = 0.969 - unc;
+	  }
+	}
+	else{
+          if(sampleyear == "2016"){
+            tmp.SFs[0] = 0.991;
+            float unc = tmp.Et() < 90 ? 0.01 : min(1 + (tmp.Et() - 90) * 0.0143, 0.04);
+            tmp.SFs[1] = 0.991 + unc;
+            tmp.SFs[2] = 0.991 - unc;
+          }
+          else if(sampleyear == "2017"){
+            tmp.SFs[0] = 0.973;
+            float unc = tmp.Et() < 90 ? 0.02 : min(1 + (tmp.Et() - 90) * 0.0143, 0.05);
+            tmp.SFs[1] = 0.973 + unc;
+            tmp.SFs[2] = 0.973 - unc;
+          }
+          else if(sampleyear == "2018"){
+            tmp.SFs[0] = 0.984;
+            float unc = tmp.Et() < 90 ? 0.02 : min(1 + (tmp.Et() - 90) * 0.0143, 0.05);
+            tmp.SFs[1] = 0.984 + unc;
+            tmp.SFs[2] = 0.984 - unc;
+          }
+	}
       }
       else tmp.SFs = {1., 1., 1.};
 
@@ -430,6 +474,7 @@ public:
   }
 
   bool ReadMETFilterStatus() {
+w
     bool status = true;
     status = status && evts->Flag_goodVertices;
     status = status && evts->Flag_globalSuperTightHalo2016Filter;

--- a/Utilities/NanoAODReader.cc
+++ b/Utilities/NanoAODReader.cc
@@ -527,6 +527,7 @@ public:
 
   //function to derive event weights from SFs on objects
   void CalcEventSFweights() {
+    //set SF weights per object
     EventWeight electronW, muonW, BjetW, PUIDW, L1PreFiringW;
     electronW.source = "electron";
     electronW.variations = {1.,1.,1.};
@@ -560,13 +561,30 @@ public:
     }
     else L1PreFiringW.variations = {1.,1.,1.};
 
-    EventWeights.push_back(electronW);
-    EventWeights.push_back(muonW);
-    EventWeights.push_back(BjetW);
-    EventWeights.push_back(PUIDW);
-    EventWeights.push_back(L1PreFiringW);
+    SFweights.push_back(electronW);
+    SFweights.push_back(muonW);
+    SFweights.push_back(BjetW);
+    SFweights.push_back(PUIDW);
+    SFweights.push_back(L1PreFiringW);
     //FIXME: Needs PDF weight variations and ISR/FSR
+
+    //determine nominal event weight
+    float CentralWeight = 1.;
+    for(unsigned i = 0; i < SFweights.size(); ++i){
+      CentralWeight *= SFweights[i].variations[0];
+    }
+    EventWeights.push_back(make_pair(CentralWeight, "Nominal"));
+
+    //select source for up and down variations
+    for(unsigned i = 0; i < SFweights.size(); ++i){
+
+      //create variations with strings for later combine histograms
+      EventWeights.push_back(make_pair(CentralWeight / SFweights[i].variations[0] * SFweights[i].variations[1], SFweights[i].source + "_down"));
+      EventWeights.push_back(make_pair(CentralWeight / SFweights[i].variations[0] * SFweights[i].variations[2], SFweights[i].source + "_up"));
+    }
   }
+
+  
 
   Configs *conf;
 
@@ -594,7 +612,8 @@ public:
   // bool LumiStatus;
   
   RegionID RegionAssociations;
-  vector<EventWeight> EventWeights;
+  vector<EventWeight> SFweights;
+  vector<pair<double, string> > EventWeights;
 };
 
 

--- a/Utilities/NanoAODReader.cc
+++ b/Utilities/NanoAODReader.cc
@@ -474,7 +474,6 @@ public:
   }
 
   bool ReadMETFilterStatus() {
-w
     bool status = true;
     status = status && evts->Flag_goodVertices;
     status = status && evts->Flag_globalSuperTightHalo2016Filter;


### PR DESCRIPTION
This solves #10 and #2.
#7 is now indirectly solved by Andrew doing this for us, so it's read from the ntuples directly.
There is still nothing that actually runs this on a set of files, and I don't yet understand your multi-layered logic of configuration at all. I'll keep hacking it, removing the analyzer.cc and ScaleFactor.cc and probably all external configurations in the process, until I can actually test this.
