### PR TITLE
First running version of the combine card macro, single-year, all masses

### DIFF
--- a/CombineMacros/CombineControl.py
+++ b/CombineMacros/CombineControl.py
@@ -1,0 +1,128 @@
+import os, sys
+import ROOT
+
+#define the input names
+signalNames = ["M$MASS"] #$MASS gets replaced by runing combine with -m option, supports only 1 signal mass at a time
+bgrNames = ["ttbar", "wjets", "single_top", "diboson"]
+binNumber = 1152 #this needs to be set
+yearNumber = 2018
+binName = "Wprime" + str(binNumber)
+
+#First, generate the shape variation histograms
+#print("Starting processing of intermediate files")
+#if os.path.isdir("TestHistograms"):
+#  os.system("rm TestHistograms/*.root") #reset 
+#else:
+#  os.system("mkdir TestHistograms") #make directory, if it doesn't exist
+#os.system("root -l -b -q 'runCombineHistogramDumpster.C+(" + str(binNumber) + ", " + str(yearNumber) + ")'") #This does not yet provide a year, as only 2018 is processed
+#os.system("hadd -f SimpleShapes_" + binName + ".root TestHistograms/*.root") #hadd all histograms to a convenient combined file
+
+#define all the systematic names, types, and values
+systNames = ["lumi", "electron", "muonTrigger", "muonId", "muonIso", "BjetTag", "PUID", "L1PreFiring", "PUreweight", "PDF",  "LHEScale", "electronScale", "electronRes", "JES",  "JER"]
+systTypes = ["lnN",  "shape"   , "shape"      , "shape",  "shape",   "shape",   "shape","shape",       "shape",      "shape","shape",    "shape",         "shape",       "shape","shape"] 
+systVals  = ["1.025","1"       , "1",           "1",      "1",       "1",       "1",    "1",           "1",          "1",    "1",        "1",             "1",           "1",    "1"]
+
+#write the actual combine card
+print("Creating Combine card file")
+f = open("Test_" + binName + ".txt","w")
+f.write("imax " + str(1) + "\n") #number of channels
+f.write("jmax " + str(len(bgrNames)) + "\n") #number of backgrounds
+f.write("kmax " + str(len(systNames)) + "\n") #number of nuisance parameters
+f.write("----------\n")
+f.write("shapes * * SimpleShapes_" + binName + ".root $PROCESS_$CHANNEL $PROCESS_$CHANNEL_$SYSTEMATIC\n")
+f.write("----------\n")
+f.write("bin         " + binName + "\n")
+
+#load ROOT file, find observation number
+print("Reading observed events numbers")
+r = ROOT.TFile.Open("SimpleShapes_" + binName + ".root", "read")
+h = r.Get("data_obs_" + binName)
+observed = h.Integral()
+f.write("observation " + str(observed) + "\n")
+f.write("----------\n")
+
+##assemble strings for lines
+print("Assembling lines for Combine card")
+#sysetmatic lines first, as this is an entire column to be processed, later, and they are longest
+systLines = []
+maxLength = 0
+for i in range(0, len(systNames)): #assemble systematic names
+  systLines.append(systNames[i])
+  maxLength = max(maxLength, len(systLines[i]))
+
+maxLength2 = 0
+for i in range(0, len(systLines)): #align systematic names, then assemble systematic types
+  while len(systLines[i]) < (maxLength + 3):
+    systLines[i] += " "
+  systLines[i] += systTypes[i]
+  maxLength2 = max(maxLength2, len(systLines[i]))
+
+for i in range(0, len(systLines)): #align syst types
+  while len(systLines[i]) < (maxLength2 + 5):
+    systLines[i] += " "
+
+maxLength2 = len(systLines[0])
+
+#assemble bin and process block
+allNames = signalNames + bgrNames
+allNumbers = []
+for i in range(-len(signalNames)+1, 1): #negative and zero numbers for signals
+  allNumbers.append(i)
+for i in range (1, len(bgrNames)+1): #positive nonzero numbers for backgrounds
+  allNumbers.append(i)
+binLine      = "bin     "
+processLine1 = "process "
+processLine2 = "process "
+rateLine     = "rate    "
+
+#align bin, process, and rate lines with systematic line length
+while len(binLine) < maxLength2:
+  binLine += " "
+while len(processLine1) < maxLength2:
+  processLine1 += " "
+while len(processLine2) < maxLength2:
+  processLine2 += " "
+while len(rateLine) < maxLength2:
+  rateLine += " "
+
+for i in range(0, len(allNames)): #assemble bin, process, rate, and systematic line entries, then align
+  binLine += binName
+  processLine1 += allNames[i]
+  processLine2 += str(allNumbers[i])
+  rateLine += "-1" #this option makes Combine read the rate from the histogram integrals
+
+  currentLength = max(len(binLine), len(processLine1), len(processLine2), len(rateLine))
+  
+  for j in range(0, len(systLines)): #assemble systematic values
+    systLines[j] += systVals[j]
+    currentLength = max(currentLength, len(systLines[j]))
+
+  #align all lines with extra space
+  currentLength += 5
+
+  while len(binLine) < currentLength:
+    binLine += " "
+
+  while len(processLine1) < currentLength:
+    processLine1 += " "
+
+  while len(processLine2) < currentLength:
+    processLine2 += " "
+
+  while len(rateLine) < currentLength:
+    rateLine += " "
+
+  for j in range(0, len(systLines)):
+    while len(systLines[j]) < currentLength:
+      systLines[j] += " "
+
+print("Writing Combine Card values")
+f.write(binLine + "\n")
+f.write(processLine1 + "\n")
+f.write(processLine2 + "\n")
+f.write(rateLine + "\n")
+f.write("----------\n")
+
+for i in range(0, len(systLines)):
+  f.write(systLines[i] + "\n")
+

--- a/CombineMacros/CombineControl.py
+++ b/CombineMacros/CombineControl.py
@@ -9,13 +9,13 @@ yearNumber = 2018
 binName = "Wprime" + str(binNumber)
 
 #First, generate the shape variation histograms
-#print("Starting processing of intermediate files")
-#if os.path.isdir("TestHistograms"):
-#  os.system("rm TestHistograms/*.root") #reset 
-#else:
-#  os.system("mkdir TestHistograms") #make directory, if it doesn't exist
-#os.system("root -l -b -q 'runCombineHistogramDumpster.C+(" + str(binNumber) + ", " + str(yearNumber) + ")'") #This does not yet provide a year, as only 2018 is processed
-#os.system("hadd -f SimpleShapes_" + binName + ".root TestHistograms/*.root") #hadd all histograms to a convenient combined file
+print("Starting processing of intermediate files")
+if os.path.isdir("TestHistograms"):
+  os.system("rm TestHistograms/*.root") #reset 
+else:
+  os.system("mkdir TestHistograms") #make directory, if it doesn't exist
+os.system("root -l -b -q 'runCombineHistogramDumpster.C+(" + str(binNumber) + ", " + str(yearNumber) + ")'") #This does not yet provide a year, as only 2018 is processed
+os.system("hadd -f SimpleShapes_" + binName + ".root TestHistograms/*.root") #hadd all histograms to a convenient combined file
 
 #define all the systematic names, types, and values
 systNames = ["lumi", "electron", "muonTrigger", "muonId", "muonIso", "BjetTag", "PUID", "L1PreFiring", "PUreweight", "PDF",  "LHEScale", "electronScale", "electronRes", "JES",  "JER"]

--- a/CombineMacros/CombineHistogramDumpster.C
+++ b/CombineMacros/CombineHistogramDumpster.C
@@ -1,0 +1,119 @@
+#define CombineHistogramDumpster_cxx
+#include "CombineHistogramDumpster.h"
+#include <TH1.h>
+#include <TStyle.h>
+#include <TCanvas.h>
+
+void CombineHistogramDumpster::Loop()
+{
+//   In a ROOT session, you can do:
+//      root> .L CombineHistogramDumpster.cc.C
+//      root> CombineHistogramDumpster.cc t
+//      root> t.GetEntry(12); // Fill t data members with entry number 12
+//      root> t.Show();       // Show values of entry 12
+//      root> t.Show(16);     // Read and show values of entry 16
+//      root> t.Loop();       // Loop on all entries
+//
+
+//     This is the loop skeleton where:
+//    jentry is the global entry number in the chain
+//    ientry is the entry number in the current Tree
+//  Note that the argument to GetEntry must be:
+//    jentry for TChain::GetEntry
+//    ientry for TTree::GetEntry and TBranch::GetEntry
+//
+//       To read only selected branches, Insert statements like:
+// METHOD1:
+//    fChain->SetBranchStatus("*",0);  // disable all branches
+//    fChain->SetBranchStatus("branchname",1);  // activate branchname
+// METHOD2: replace line
+//    fChain->GetEntry(jentry);       //read all branches
+//by  b_branchname->GetEntry(ientry); //read only this branch
+
+   //define bin for analysis
+   TString binS = TString::Format("Wprime%d", bin);
+   //define variations
+   vector<TH1F*> WPrimeMass_FL;
+   //first variations are all weight variations and map 1:1, region variations start at index 21
+   vector<TString> variations = {dset.GroupName + "_" + binS, 
+                                 dset.GroupName + "_" + binS + "_" + "electronUp",
+                                 dset.GroupName + "_" + binS + "_" + "electronDown",
+				 dset.GroupName + "_" + binS + "_" + "muonTriggerUp",
+				 dset.GroupName + "_" + binS + "_" + "muonTriggerDown",
+				 dset.GroupName + "_" + binS + "_" + "muonIdUp",
+				 dset.GroupName + "_" + binS + "_" + "muonIdDown",
+				 dset.GroupName + "_" + binS + "_" + "muonIsoUp",
+				 dset.GroupName + "_" + binS + "_" + "muonIsoDown",
+				 dset.GroupName + "_" + binS + "_" + "BjetTagUp",
+				 dset.GroupName + "_" + binS + "_" + "BjetTagDown",
+				 dset.GroupName + "_" + binS + "_" + "PUIDUp",
+				 dset.GroupName + "_" + binS + "_" + "PUIDDown",
+				 dset.GroupName + "_" + binS + "_" + "L1PreFiringUp",
+				 dset.GroupName + "_" + binS + "_" + "L1PreFiringDown",
+				 dset.GroupName + "_" + binS + "_" + "PUreweightUp",
+				 dset.GroupName + "_" + binS + "_" + "PUreweightDown",
+				 dset.GroupName + "_" + binS + "_" + "PDFUp",
+				 dset.GroupName + "_" + binS + "_" + "PDFDown",
+				 dset.GroupName + "_" + binS + "_" + "LHEScaleUp",
+				 dset.GroupName + "_" + binS + "_" + "LHEScaleDown",
+				 dset.GroupName + "_" + binS + "_" + "electronScaleUp",
+				 dset.GroupName + "_" + binS + "_" + "electronScaleDown",
+				 dset.GroupName + "_" + binS + "_" + "electronResUp",
+				 dset.GroupName + "_" + binS + "_" + "electronResDown",
+				 dset.GroupName + "_" + binS + "_" + "JESUp",
+				 dset.GroupName + "_" + binS + "_" + "JESDown",
+				 dset.GroupName + "_" + binS + "_" + "JERUp",
+				 dset.GroupName + "_" + binS + "_" + "JERDown"};
+   for(unsigned i = 0; i < variations.size(); ++i) WPrimeMass_FL.push_back(new TH1F(variations[i],"W' mass, simplified, FL case; m_{W'} [GeV/c^{2}]; Events", 400, 0., 2000.));
+
+   if (fChain == 0) return;
+
+   Long64_t nentries = fChain->GetEntriesFast();
+
+   Long64_t nbytes = 0, nb = 0;
+   for (Long64_t jentry=0; jentry<nentries;jentry++) {
+      Long64_t ientry = LoadTree(jentry);
+      if (ientry < 0) break;
+      nb = fChain->GetEntry(jentry);   nbytes += nb;
+
+      //set sample weight
+      int Year = 0;
+      float Lumi = 0.;
+      if(YearType == "2016_APV")  {Year = 0; Lumi = 0.;}
+      else if(YearType == "2016") {Year = 1; Lumi = 41.58;}
+      else if(YearType == "2017") {Year = 2; Lumi = 49.81;}
+      else if(YearType == "2018") {Year = 3; Lumi = 67.86;}
+      float SampleWeight = 1.;
+      if(dset.Type != 0) SampleWeight = Lumi * dset.CrossSection / dset.Size[Year];
+
+      //Muon type variations, for a test
+      if(RegionIdentifier[0] == bin){
+        //EventWeight variations
+        for(unsigned i = 0; i < 21; ++i){
+          string HistName;
+          WPrimeMass_FL[i]->Fill(WPrimeMassSimpleFL->at(0),EventWeight[i]*SampleWeight);
+	}
+      }
+      //variations of selections
+      for(unsigned i = 1; i < 9; ++ i){
+	if(RegionIdentifier[i] != bin) continue;
+	string HistName;
+	WPrimeMass_FL[i+20]->Fill(WPrimeMassSimpleFL->at(0),EventWeight[0]*SampleWeight);
+      }
+   }
+   //save all the W' variation histograms into a file
+   TFile *savefile;
+   //if(!Iterator) savefile = new TFile("TestHistograms/SimpleShapes.root","RECREATE");
+   //else savefile = new TFile("TestHistograms/SimpleShapes.root","WRITE");
+   savefile = new TFile(TString::Format("TestHistograms/SimpleShapes%d.root",Iterator),"RECREATE");
+   savefile->cd();
+   for(unsigned i = 0; i < WPrimeMass_FL.size(); ++i){
+     if(dset.Type == 0){
+	if(i>0) continue;
+	if(Iterator == 1) WPrimeMass_FL[i]->Write("data_obs_" + binS);
+	else continue;
+     }
+     else WPrimeMass_FL[i]->Write(WPrimeMass_FL[i]->GetName());
+   }
+   savefile->Close();
+}

--- a/CombineMacros/CombineHistogramDumpster.h
+++ b/CombineMacros/CombineHistogramDumpster.h
@@ -1,0 +1,233 @@
+//////////////////////////////////////////////////////////
+// This class has been automatically generated on
+// Wed May 31 13:29:44 2023 by ROOT version 6.22/09
+// from TTree t/EventTree
+// found on file: /eos/user/s/siluo/WPrimeAnalysis/Validation/2018_FL500.root
+//////////////////////////////////////////////////////////
+
+#ifndef CombineHistogramDumpster_h
+#define CombineHistogramDumpster_h
+
+#include "Dataset.cc"
+#include <TROOT.h>
+#include <TChain.h>
+#include <TFile.h>
+
+// Header file for the classes stored in the TTree if any.
+#include "vector"
+
+class CombineHistogramDumpster {
+public :
+   TTree          *fChain;   //!pointer to the analyzed TTree or TChain
+   Int_t           fCurrent; //!current Tree number in a TChain
+
+// Fixed size dimensions of array or collections stored in the TTree if any.
+
+   // Declaration of leaf types
+   Int_t           RegionIdentifier[9];
+   Float_t         EventWeight[21];
+   Float_t         LeptonPt;
+   Float_t         LeptonPt_SU;
+   Float_t         LeptonPt_SD;
+   Float_t         LeptonPt_RU;
+   Float_t         LeptonPt_RD;
+   Float_t         LeptonEta;
+   vector<float>   *JetPt;
+   vector<float>   *JetPt_SU;
+   vector<float>   *JetPt_SD;
+   vector<float>   *JetPt_RU;
+   vector<float>   *JetPt_RD;
+   vector<float>   *JetEta;
+   Float_t         METPt;
+   Float_t         METPt_SU;
+   Float_t         METPt_SD;
+   Float_t         METPt_RU;
+   Float_t         METPt_RD;
+   Float_t         METPhi;
+   vector<float>   *mT;
+   vector<float>   *WPrimeMassSimpleFL;
+   vector<float>   *WPrimeMassSimpleLL;
+   Int_t           nPU;
+   Float_t         nTrueInt;
+   Int_t           nPV;
+   Int_t           nPVGood;
+
+   // List of branches
+   TBranch        *b_RegionIdentifier;   //!
+   TBranch        *b_EventWeight;   //!
+   TBranch        *b_LeptonPt;   //!
+   TBranch        *b_LeptonPt_SU;   //!
+   TBranch        *b_LeptonPt_SD;   //!
+   TBranch        *b_LeptonPt_RU;   //!
+   TBranch        *b_LeptonPt_RD;   //!
+   TBranch        *b_LeptonEta;   //!
+   TBranch        *b_JetPt;   //!
+   TBranch        *b_JetPt_SU;   //!
+   TBranch        *b_JetPt_SD;   //!
+   TBranch        *b_JetPt_RU;   //!
+   TBranch        *b_JetPt_RD;   //!
+   TBranch        *b_JetEta;   //!
+   TBranch        *b_METPt;   //!
+   TBranch        *b_METPt_SU;   //!
+   TBranch        *b_METPt_SD;   //!
+   TBranch        *b_METPt_RU;   //!
+   TBranch        *b_METPt_RD;   //!
+   TBranch        *b_METPhi;   //!
+   TBranch        *b_mT;   //!
+   TBranch        *b_WPrimeMassSimpleFL;   //!
+   TBranch        *b_WPrimeMassSimpleLL;   //!
+   TBranch        *b_nPU;   //!
+   TBranch        *b_nTrueInt;   //!
+   TBranch        *b_nPV;   //!
+   TBranch        *b_nPVGood;   //!
+
+   CombineHistogramDumpster(TTree *tree = 0, unsigned it_ = 99, int bin_ = 1152, TString year_ = "2018");
+   virtual ~CombineHistogramDumpster();
+   virtual Int_t    Cut(Long64_t entry);
+   virtual Int_t    GetEntry(Long64_t entry);
+   virtual Long64_t LoadTree(Long64_t entry);
+   virtual void     Init(TTree *tree);
+   virtual void     Loop();
+   virtual Bool_t   Notify();
+   virtual void     Show(Long64_t entry = -1);
+
+   unsigned Iterator;
+   string YearType;
+   Dataset dset;
+   int bin;
+};
+
+#endif
+
+#ifdef CombineHistogramDumpster_cxx
+CombineHistogramDumpster::CombineHistogramDumpster(TTree *tree, unsigned it_, int bin_, TString year_) : fChain(0) 
+{
+   if(it_>39) {
+     std::cout<<"iterator out of range"<<std::endl;
+     return;
+   }
+// if parameter tree is not specified (or zero), connect the file
+// used to generate this class and read the Tree.
+   if (tree == 0) {
+      dset = dlib.GetDataset(it_);
+      TString FilePath = "/eos/user/s/siluo/WPrimeAnalysis/Validation/" + year_ + "_" + dset.Name + ".root";
+      TFile *f = new TFile(FilePath,"READ");
+      if (!f || !f->IsOpen()) {
+	std::cout<<"Failed to find File"<<std::endl;
+	return;
+      }
+      f->GetObject("t",tree);
+      Iterator = it_;
+      YearType = year_;
+      bin = bin_;
+   }
+   Init(tree);
+}
+
+CombineHistogramDumpster::~CombineHistogramDumpster()
+{
+   if (!fChain) return;
+   delete fChain->GetCurrentFile();
+}
+
+Int_t CombineHistogramDumpster::GetEntry(Long64_t entry)
+{
+// Read contents of entry.
+   if (!fChain) return 0;
+   return fChain->GetEntry(entry);
+}
+Long64_t CombineHistogramDumpster::LoadTree(Long64_t entry)
+{
+// Set the environment to read one entry
+   if (!fChain) return -5;
+   Long64_t centry = fChain->LoadTree(entry);
+   if (centry < 0) return centry;
+   if (fChain->GetTreeNumber() != fCurrent) {
+      fCurrent = fChain->GetTreeNumber();
+      Notify();
+   }
+   return centry;
+}
+
+void CombineHistogramDumpster::Init(TTree *tree)
+{
+   // The Init() function is called when the selector needs to initialize
+   // a new tree or chain. Typically here the branch addresses and branch
+   // pointers of the tree will be set.
+   // It is normally not necessary to make changes to the generated
+   // code, but the routine can be extended by the user if needed.
+   // Init() will be called many times when running on PROOF
+   // (once per file to be processed).
+
+   // Set object pointer
+   JetPt = 0;
+   JetPt_SU = 0;
+   JetPt_SD = 0;
+   JetPt_RU = 0;
+   JetPt_RD = 0;
+   JetEta = 0;
+   mT = 0;
+   WPrimeMassSimpleFL = 0;
+   WPrimeMassSimpleLL = 0;
+   // Set branch addresses and branch pointers
+   if (!tree) return;
+   fChain = tree;
+   fCurrent = -1;
+   fChain->SetMakeClass(1);
+
+   fChain->SetBranchAddress("RegionIdentifier", RegionIdentifier, &b_RegionIdentifier);
+   fChain->SetBranchAddress("EventWeight", EventWeight, &b_EventWeight);
+   fChain->SetBranchAddress("LeptonPt", &LeptonPt, &b_LeptonPt);
+   fChain->SetBranchAddress("LeptonPt_SU", &LeptonPt_SU, &b_LeptonPt_SU);
+   fChain->SetBranchAddress("LeptonPt_SD", &LeptonPt_SD, &b_LeptonPt_SD);
+   fChain->SetBranchAddress("LeptonPt_RU", &LeptonPt_RU, &b_LeptonPt_RU);
+   fChain->SetBranchAddress("LeptonPt_RD", &LeptonPt_RD, &b_LeptonPt_RD);
+   fChain->SetBranchAddress("LeptonEta", &LeptonEta, &b_LeptonEta);
+   fChain->SetBranchAddress("JetPt", &JetPt, &b_JetPt);
+   fChain->SetBranchAddress("JetPt_SU", &JetPt_SU, &b_JetPt_SU);
+   fChain->SetBranchAddress("JetPt_SD", &JetPt_SD, &b_JetPt_SD);
+   fChain->SetBranchAddress("JetPt_RU", &JetPt_RU, &b_JetPt_RU);
+   fChain->SetBranchAddress("JetPt_RD", &JetPt_RD, &b_JetPt_RD);
+   fChain->SetBranchAddress("JetEta", &JetEta, &b_JetEta);
+   fChain->SetBranchAddress("METPt", &METPt, &b_METPt);
+   fChain->SetBranchAddress("METPt_SU", &METPt_SU, &b_METPt_SU);
+   fChain->SetBranchAddress("METPt_SD", &METPt_SD, &b_METPt_SD);
+   fChain->SetBranchAddress("METPt_RU", &METPt_RU, &b_METPt_RU);
+   fChain->SetBranchAddress("METPt_RD", &METPt_RD, &b_METPt_RD);
+   fChain->SetBranchAddress("METPhi", &METPhi, &b_METPhi);
+   fChain->SetBranchAddress("mT", &mT, &b_mT);
+   fChain->SetBranchAddress("WPrimeMassSimpleFL", &WPrimeMassSimpleFL, &b_WPrimeMassSimpleFL);
+   fChain->SetBranchAddress("WPrimeMassSimpleLL", &WPrimeMassSimpleLL, &b_WPrimeMassSimpleLL);
+   fChain->SetBranchAddress("nPU", &nPU, &b_nPU);
+   fChain->SetBranchAddress("nTrueInt", &nTrueInt, &b_nTrueInt);
+   fChain->SetBranchAddress("nPV", &nPV, &b_nPV);
+   fChain->SetBranchAddress("nPVGood", &nPVGood, &b_nPVGood);
+   Notify();
+}
+
+Bool_t CombineHistogramDumpster::Notify()
+{
+   // The Notify() function is called when a new file is opened. This
+   // can be either for a new TTree in a TChain or when when a new TTree
+   // is started when using PROOF. It is normally not necessary to make changes
+   // to the generated code, but the routine can be extended by the
+   // user if needed. The return value is currently not used.
+
+   return kTRUE;
+}
+
+void CombineHistogramDumpster::Show(Long64_t entry)
+{
+// Print contents of entry.
+// If entry is not specified, print current entry
+   if (!fChain) return;
+   fChain->Show(entry);
+}
+Int_t CombineHistogramDumpster::Cut(Long64_t entry)
+{
+// This function may be called from Loop.
+// returns  1 if entry is accepted.
+// returns -1 otherwise.
+   return 1;
+}
+#endif // #ifdef CombineHistogramDumpster_cxx

--- a/CombineMacros/Dataset.cc
+++ b/CombineMacros/Dataset.cc
@@ -1,0 +1,301 @@
+#ifndef DATASET_CC
+#define DATASET_CC
+
+#include "TString.h"
+#include "TH1.h"
+#include "TLegend.h"
+
+#include <vector>
+#include <map>
+#include <iostream>
+
+using namespace std;
+
+struct Dataset {
+  TString Name;
+  TString GroupName;
+  int Index;
+  int Type; // 0: Data, 1: MC, 2: Signal
+  int Color;
+  double CrossSection; // Unit in fb
+  vector<double> Size;
+
+  void Print(int verbosity = 0) {
+    vector<TString> types{"Data","MC","Signal"};
+    vector<TString> colors{"white","black","red","green","blue","yellow","magenta","cyan","lush green","purple"};
+    //                       0       1      2      3      4       5         6        7        8          9
+    cout << "Dataset: " << Name << " ,Index = " << Index << ", (" << types[Type] << ")" <<endl;
+    if (verbosity < 1) return;
+    cout << "         CrossSection = " << CrossSection << ", Sample Size  = ";
+    for (unsigned i = 0; i < Size.size(); ++i) cout << Size[i] << ", ";
+    if (Size.size() != 4) cout << "Not well defined";
+    cout << endl;
+    if (verbosity < 2) return;
+    cout << "         Plot group is " << GroupName << ", Colored " << Color;
+    if (Color < (int) colors.size()) cout << " (" << colors[Color] << ") ";
+    cout << endl;
+  }
+};
+
+struct DatasetGroup {
+  TString GroupName;
+  int Color;
+  int Type;
+  vector<TString> DatasetNames;
+  TH1F* dummy;
+  void MakeDummyHist() {
+    
+    dummy->SetLineColor(Color);
+  }
+  void AddLegend(TLegend *l) {
+    TString gname = GroupName;
+    if (dummy == nullptr) dummy = new TH1F(gname + "_dummy","dummy",2,0,2);
+    dummy->SetLineColor(Color);
+    if (Type == 0) {
+      dummy->SetLineStyle(1);
+      dummy->SetMarkerStyle(20);
+      l->AddEntry(dummy, gname, "p");
+    }
+    else if (Type == 1) {
+      dummy->SetLineStyle(1);
+      dummy->SetFillColor(Color);
+      l->AddEntry(dummy, gname, "f");
+    }
+    else if (Type == 2) {
+      dummy->SetLineStyle(2);
+      dummy->SetLineWidth(2);
+      l->AddEntry(dummy, gname, "l");
+    }
+  }
+};
+
+class DatasetsLib {
+public:
+  DatasetsLib() {
+    Debug = false;
+    Init();
+    SortGroups();
+  };
+
+  void Init() {
+    Datasets.clear();
+    DatasetNames.clear();
+    Groups.clear();
+    GroupNames.clear();
+    // Add Dataset with parameters as Name, Group Name, Type(0:Data, 1:MC, 2:Signal), Color, Xsection(In fb), SampleSize
+    //                Name                      Group Name     Type Color  Xsection   SampleSizes for each year
+    AddDataset_NGTCXS("SingleElectron"         ,"Data"          , 0, 1 , 1., {1,1,1,1}); // 0
+    AddDataset_NGTCXS("SingleMuon"             ,"Data"          , 0, 1 , 1., {1,1,1,1}); // 1
+
+    AddDataset_NGTCXS("ttbar"                  ,"ttbar"         , 1, 2 , 365974.4, {1, 144722000, 346052000, 476408000}); // 2
+
+    AddDataset_NGTCXS("wjets_HT_70_100"        ,"wjets"         , 1, 3 , 1353000, {1, 19439931, 44576510, 66220256}); // 3
+    AddDataset_NGTCXS("wjets_HT_100_200"       ,"wjets"         , 1, 3 , 1627450, {1, 19753958, 47424468, 51408967}); // 4
+    AddDataset_NGTCXS("wjets_HT_200_400"       ,"wjets"         , 1, 3 , 435237,  {1, 15067621, 42281979, 58225632}); // 5
+    AddDataset_NGTCXS("wjets_HT_400_600"       ,"wjets"         , 1, 3 , 59181,   {1, 2115509, 5468473, 7444030}); // 6
+    AddDataset_NGTCXS("wjets_HT_600_800"       ,"wjets"         , 1, 3 , 14581,   {1, 2251807, 5545298, 7718765}); // 7
+    AddDataset_NGTCXS("wjets_HT_800_1200"      ,"wjets"         , 1, 3 , 6656,    {1, 2132228, 5088483, 7306187}); // 8
+    AddDataset_NGTCXS("wjets_HT_1200_2500"     ,"wjets"         , 1, 3 , 1608,    {1, 2090561, 4752118, 6481518}); // 9
+    AddDataset_NGTCXS("wjets_HT_2500_inf"      ,"wjets"         , 1, 3 , 39,      {1, 709514, 1185699, 2097648}); // 10
+    // AddDataset_NGTCXS("wjets_inclusive"        ,"wjets"         , 1, 3 , 0,       {0,0,0,0});                     
+
+    AddDataset_NGTCXS("single_top_schan"       ,"single_top"    , 1, 4 , 3740,   {1,5471000,13620000,19365999}); // 11
+    AddDataset_NGTCXS("single_top_tchan"       ,"single_top"    , 1, 4 , 115300, {1,63073000,129903000,178336000}); // 12
+    AddDataset_NGTCXS("single_antitop_tchan"   ,"single_top"    , 1, 4 , 69090,  {1,30609000,69793000,95627000}); // 13
+    AddDataset_NGTCXS("single_top_tw"          ,"single_top"    , 1, 4 , 34910,  {1,3368375,8507203,11270430}); // 14
+    AddDataset_NGTCXS("single_antitop_tw"      ,"single_top"    , 1, 4 , 34970,  {1,3654510,8433998,10949620}); // 15
+
+    AddDataset_NGTCXS("WW"                     ,"diboson"       , 1, 5 , 51650,  {1, 19976139, 39931603, 40272013}); // 16
+    AddDataset_NGTCXS("ZZ"                     ,"diboson"       , 1, 5 , 12170,  {1, 1151000, 2706000, 3526000}); // 17
+    AddDataset_NGTCXS("WZTo1L1Nu2Q"            ,"diboson"       , 1, 5 , 9119,   {1, 3690271, 7345742, 7395487}); // 18
+    AddDataset_NGTCXS("WZTo1L3Nu"              ,"diboson"       , 1, 5 , 3414,   {1, 2468727, 2481654, 2497292}); // 19
+    AddDataset_NGTCXS("WZTo2Q2L"               ,"diboson"       , 1, 5 , 6565,   {1, 13526954, 29091996, 28576996}); // 20
+    AddDataset_NGTCXS("WZTo3LNu"               ,"diboson"       , 1, 5 , 4430,   {1, 20810003, 10339582, 38624209}); // 21
+
+    // McM page
+    // https://cms-pdmv.cern.ch/mcm/requests?range=B2G-RunIISummer20UL16wmLHEGEN-03230,B2G-RunIISummer20UL16wmLHEGEN-03247&page=0&shown=127
+    // DAS request dataset wildcard
+    // dataset=/btWprimeToBottomTop_*Leptonic_M-*_TuneCP5_13TeV-madgraphMLM-pythia8/*/NANOAODSIM
+    // Example command to get the sample size:
+    // for i in 3 4 5 6 7 8 9 10 11; do dasgoclient -query="dataset=/btWprimeToBottomTop_LatterLeptonic_M-${i}00_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16NanoAODAPVv9-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM | grep dataset.nevents"; done
+    AddDataset_NGTCXS("FL300"                  ,"M300"            , 2, 4 , 683.8,  {542974, 451706, 989541, 973312}); // 22
+    AddDataset_NGTCXS("FL400"                  ,"M400"            , 2, 5 , 321.7,  {542917, 457628, 1009763, 1005777}); // 23
+    AddDataset_NGTCXS("FL500"                  ,"M500"            , 2, 6 , 161.1,  {539889, 472634, 990910, 995846}); // 24
+    AddDataset_NGTCXS("FL600"                  ,"M600"            , 2, 7 , 85.92,  {538626, 459533, 1002905, 1013268}); // 25
+    AddDataset_NGTCXS("FL700"                  ,"M700"            , 2, 8 , 48.84,  {0, 458032, 993657, 1007434}); // 26
+    AddDataset_NGTCXS("FL800"                  ,"M800"            , 2, 9 , 29.81,  {544804, 457557, 989717, 994770}); // 27
+    AddDataset_NGTCXS("FL900"                  ,"M900"            , 2, 30, 18.33,  {537197, 459185, 996690, 1014207}); // 28
+    AddDataset_NGTCXS("FL1000"                 ,"M1000"           , 2, 40, 11.73,  {533034, 443584, 999049, 999380}); // 29
+    AddDataset_NGTCXS("FL1100"                 ,"M1100"           , 2, 46, 7.683,  {467268, 466768, 1001850, 986599}); // 30
+
+    AddDataset_NGTCXS("LL300"                  ,"M300"            , 2, 4 , 708.3,  {533339, 463438, 1016545, 979122}); // 31
+    AddDataset_NGTCXS("LL400"                  ,"M400"            , 2, 5 , 336.1,  {527708, 451102, 991505, 990858}); // 32
+    AddDataset_NGTCXS("LL500"                  ,"M500"            , 2, 6 , 165.3,  {548554, 462578, 990701, 1001088}); // 33
+    AddDataset_NGTCXS("LL600"                  ,"M600"            , 2, 7 , 85.82,  {530042, 467804, 997101, 995847}); // 34
+    AddDataset_NGTCXS("LL700"                  ,"M700"            , 2, 8 , 47.47,  {539337, 454955, 999882, 993510}); // 35
+    AddDataset_NGTCXS("LL800"                  ,"M800"            , 2, 9 , 27.73,  {0, 462499, 978958, 988361}); // 36
+    AddDataset_NGTCXS("LL900"                  ,"M900"            , 2, 30, 16.49,  {0, 464288, 1015927, 1006881}); // 37
+    AddDataset_NGTCXS("LL1000"                 ,"M1000"           , 2, 40, 10.25,  {540970, 457909, 998840, 1008866}); // 38
+    AddDataset_NGTCXS("LL1100"                 ,"M1100"           , 2, 46, 6.546,  {535810, 461040, 990631, 1010305}); // 39
+
+    // AddDataset_NGTCXS("Private_FL_M500"        ,""              , 2, 7 , 161.1,  {1,1,1,189291});
+  }
+  // Adding Dataset with parameters as Name, Group name, Type (0:Data,1:MC,2:Signal), Color, Xsection, SampleSize
+  int AddDataset_NGTCXS(TString name, TString gname = "", int type = 2, int color = 3, double xsec = 1.0, vector<double> size = {}) {
+    if (Datasets.find(name) != Datasets.end()) {
+      return Datasets[name].Index;
+    }
+    Dataset ds;
+    ds.Name = name;
+    ds.Index = DatasetNames.size();
+    ds.Type = type;
+    ds.Color = color;
+    ds.CrossSection = xsec;
+    ds.Size = size;
+    if (gname == "") ds.GroupName = name;
+    else ds.GroupName = gname;
+    DatasetNames.push_back(name);
+    Datasets[name] = ds;
+    return ds.Index;
+  }
+
+  void ListDatasets() {
+    cout << endl;
+    for (unsigned i = 0; i < DatasetNames.size(); ++i) {
+      Datasets[DatasetNames[i]].Print();
+    }
+  }
+
+  void SortGroups() {
+    // By default, sort the Groups by MC backgroup, Signal and Data comes last.
+    vector<int> typeorder{1,2,0};
+    for (unsigned i = 0; i < 3; ++i) {
+      for (unsigned ids = 0; ids < DatasetNames.size(); ++ids) {
+        Dataset& ds = GetDataset(DatasetNames[ids]);
+        if (ds.Type != typeorder[i]) continue;
+        if (Groups[ds.GroupName].DatasetNames.size() == 0) { // First occurance of a GroupName
+          GroupNames.push_back(ds.GroupName);
+          Groups[ds.GroupName].Color = ds.Color;
+          Groups[ds.GroupName].Type = ds.Type;
+          Groups[ds.GroupName].GroupName = ds.GroupName;
+        }
+        Groups[ds.GroupName].DatasetNames.push_back(ds.Name);
+      }
+    }
+  }
+
+  void GroupOrder() { // When need to override the order in which the hist groups are drawn
+    GroupNames = {"ttbar","wjets","single_top","diboson","M300","M400","M500","M600","M700","M800","M900","M1000","M1100"};
+    GroupNames.push_back("Data");
+  }
+
+  void AddLegend(TLegend *leg, bool IsSR) {
+    for (unsigned i = 0; i < GroupNames.size(); ++i) {
+      if (IsSR && GroupNames[i] == "Data") continue;
+      Groups[GroupNames[i]].AddLegend(leg);
+    }
+  }
+
+  bool CheckExist(TString ds, TString funcname = "") {
+    if (!Debug) return true;
+    bool found = (Datasets.find(ds) != Datasets.end());
+    if (!found) {
+      TString msg =  "Dataset " + ds + " no found while running function " + funcname;
+      cout << msg <<endl;
+      throw runtime_error(msg);
+    }
+    return found;
+  }
+
+  void PrintDatasets(int verbose = 0) {
+    for (unsigned i = 0; i < DatasetNames.size(); ++i) {
+      Dataset &ds = GetDataset(DatasetNames[i]);
+      ds.Print();
+    }
+  } 
+
+  Dataset& GetDataset(TString ds) {
+    CheckExist(ds,"GetDataset");
+    return Datasets[ds];
+  }
+
+  Dataset& GetDataset(unsigned i) {
+    if (i >= Datasets.size()) {
+      TString msg = "Index exceeding the size of all Datasets";
+      cout << msg << endl;
+      throw runtime_error(msg);
+    }
+    return Datasets[DatasetNames[i]];
+  }
+
+  double GetCMSLumi(int i) {
+    return CMSLumiYears[i];
+  }
+
+  int GetIndex(TString ds) {
+    CheckExist(ds,"GetIndex");
+    return Datasets[ds].Index;
+  }
+
+  TString GetGroup(TString ds) {
+    CheckExist(ds,"GetGroup");
+    return Datasets[ds].GroupName;
+  }
+  
+  int GetGroupIndexFromDatasetName(TString ds) {
+    CheckExist(ds,"GetGroupIndexFromDatasetName");
+    return GetGroupIndexFromGroupName(GetGroup(ds));
+  }
+
+  int GetGroupIndexFromGroupName(TString gp) {
+    for (unsigned ig = 0; ig < GroupNames.size(); ++ig) {
+      if (gp == GroupNames[ig]) return ig;
+    }
+    return -1;
+  }
+
+  bool DatasetInList(int ist, vector<TString> list) {
+    for (unsigned i = 0; i < list.size(); ++i) {
+      if (DatasetNames[ist] == list[i]) return true;
+    }
+    return false;
+  }
+
+  int GetType(TString ds) {
+    CheckExist(ds, "GetType");
+    return Datasets[ds].Type;
+  }
+
+  int GetColor(TString ds) {
+    CheckExist(ds, "GetColor");
+    return Datasets[ds].Color;
+  }
+
+  double GetXsec(TString ds) {
+    CheckExist(ds, "GetXsec");
+    return Datasets[ds].CrossSection;
+  }
+
+  double GetSize(TString ds, int y) {
+    CheckExist(ds, "GetSize");
+    return Datasets[ds].Size[y];
+  }
+
+  double GetNormFactor(TString ds, int y) {
+    if (GetType(ds) == 0) return 1;
+    return CMSLumiYears[y] * GetXsec(ds) / GetSize(ds,y);
+  }
+
+
+  bool Debug;
+  const vector<TString> SampleYears{"2016apv","2016","2017","2018"};
+  const vector<double> CMSLumiYears{19.52, 16.81, 41.48, 59.83};
+  vector<TString> DatasetNames, GroupNames;
+  map<TString,DatasetGroup> Groups;
+  map<TString,Dataset> Datasets;
+
+};
+
+DatasetsLib dlib;
+
+#endif

--- a/CombineMacros/runCombineHistogramDumpster.C
+++ b/CombineMacros/runCombineHistogramDumpster.C
@@ -1,0 +1,10 @@
+#include "CombineHistogramDumpster.C"
+
+void runCombineHistogramDumpster(int bin = 1152, int year = 2018){
+  for(unsigned i = 0; i < 40; ++i){
+    if(bin/1000 == 1 && i == 0) continue;
+    else if(bin/2000 == 1 && i == 1) continue;
+    CombineHistogramDumpster D(0, i, 1152, TString::Format("%d", year)); //don't supply a year, for now, there are no options
+    D.Loop();
+  }
+}


### PR DESCRIPTION
Set up Combine as in https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/
Copy CombineMacros folder into CMSSW release with combine, set up cmsenv.
Then run:
python CombineControl.py
Set the single top PDF systematic to - for now, manually, in Test_Wprime1152.txt
combine -d Test_Wprime1152.txt -m 300

Output test on isolated muons, 5 jets, 2 b-tags configuration:
` <<< Combine >>>
>>> random number generator seed is 123456
>>> method used is AsymptoticLimits
SimNLL created with 1 channels, 0 generic constraints, 15 fast gaussian constraints, 0 fast poisson constraints, 0 fast group constraints,
SimNLL created with 1 channels, 0 generic constraints, 15 fast gaussian constraints, 0 fast poisson constraints, 0 fast group constraints,
SimNLL created with 1 channels, 0 generic constraints, 15 fast gaussian constraints, 0 fast poisson constraints, 0 fast group constraints,

 -- AsymptoticLimits ( CLs ) --
Observed Limit: r < 0.2525
Expected  2.5%: r < 0.9290
Expected 16.0%: r < 1.2344
Expected 50.0%: r < 1.7109
Expected 84.0%: r < 2.3725
Expected 97.5%: r < 3.1353`