### PR TITLE
Combine improvements & electron SF fix

### DIFF
--- a/CombineMacros/CombineControl.py
+++ b/CombineMacros/CombineControl.py
@@ -6,6 +6,8 @@ signalNames = ["M$MASS"] #$MASS gets replaced by runing combine with -m option, 
 bgrNames = ["ttbar", "wjets", "single_top", "diboson"]
 binNumber = 1152 #this needs to be set
 yearNumber = 2018
+
+yearName = str(yearNumber)
 binName = "Wprime" + str(binNumber)
 
 #First, generate the shape variation histograms
@@ -17,10 +19,24 @@ else:
 os.system("root -l -b -q 'runCombineHistogramDumpster.C+(" + str(binNumber) + ", " + str(yearNumber) + ")'") #This does not yet provide a year, as only 2018 is processed
 os.system("hadd -f SimpleShapes_" + binName + ".root TestHistograms/*.root") #hadd all histograms to a convenient combined file
 
+#define correlated entities for usage in card
+#https://twiki.cern.ch/twiki/bin/view/CMS/LumiRecommendationsRun2#Combination_and_correlations
+lumiCorrVal = "0.0"
+lumiStatVal = "0.0"
+if yearNumber == 2016:
+  lumiCorrVal = "0.6"
+  lumiStatVal = "1.0"
+if yearNumber == 2017:
+  lumiCorrVal = "0.9"
+  lumiStatVal = "2.0"
+if yearNumber == 2018:
+  lumiCorrVal = "2.0"
+  lumiStatVal = "1.5"
+
 #define all the systematic names, types, and values
-systNames = ["lumi", "electron", "muonTrigger", "muonId", "muonIso", "BjetTagCorr", "BjetTagUncorr", "PUID",  "L1PreFiring", "PUreweight", "PDF",  "LHEScale", "electronScale", "electronRes", "JES",  "JER"]
-systTypes = ["lnN",  "shape"   , "shape"      , "shape",  "shape",   "shape",       "shape",         "shape", "shape",       "shape",      "shape","shape",    "shape",         "shape",       "shape","shape"] 
-systVals  = ["1.025","1"       , "1",           "1",      "1",       "1",           "1",             "1",     "1",           "1",          "1",    "1",        "1",             "1",           "1",    "1"]
+systNames = ["lumiCorr",  "lumiStat"+yearName, "electron", "muonTrigger", "muonId", "muonIso", "BjetTagCorr", "BjetTagUncorr"+yearName, "PUID",  "L1PreFiring", "PUreweight", "PDF",   "LHEScale", "electronScale", "electronRes", "JES",   "JER"]
+systTypes = ["lnN",       "lnN",               "shape",    "shape",       "shape",  "shape",   "shape",       "shape",                  "shape", "shape",       "shape",      "shape", "shape",    "shape",         "shape",       "shape", "shape"] 
+systVals  = [lumiCorrVal, lumiStatVal,         "1",        "1",           "1",      "1",       "1",           "1",                      "1",     "1",           "1",          "1",     "1",        "1",             "1",           "1",     "1"]
 
 #write the actual combine card
 print("Creating Combine card file")

--- a/CombineMacros/CombineControl.py
+++ b/CombineMacros/CombineControl.py
@@ -4,7 +4,7 @@ import ROOT
 #define the input names
 signalNames = ["M$MASS"] #$MASS gets replaced by runing combine with -m option, supports only 1 signal mass at a time
 bgrNames = ["ttbar", "wjets", "single_top", "diboson"]
-binNumber = 1152 #this needs to be set
+binNumber = 1153 #this needs to be set
 yearNumber = 2018
 
 yearName = str(yearNumber)
@@ -17,7 +17,7 @@ if os.path.isdir("TestHistograms"):
 else:
   os.system("mkdir TestHistograms") #make directory, if it doesn't exist
 os.system("root -l -b -q 'runCombineHistogramDumpster.C+(" + str(binNumber) + ", " + str(yearNumber) + ")'") #This does not yet provide a year, as only 2018 is processed
-os.system("hadd -f SimpleShapes_" + binName + ".root TestHistograms/*.root") #hadd all histograms to a convenient combined file
+os.system("hadd -f SimpleShapes_" + binName + ".root TestHistograms/SimpleShapes_Bin" + str(binNumber) + "*.root") #hadd all histograms to a convenient combined file
 
 #define correlated entities for usage in card
 #https://twiki.cern.ch/twiki/bin/view/CMS/LumiRecommendationsRun2#Combination_and_correlations

--- a/CombineMacros/CombineControl.py
+++ b/CombineMacros/CombineControl.py
@@ -52,7 +52,7 @@ f.write("bin         " + binName + "\n")
 #load ROOT file, find observation number
 print("Reading observed events numbers")
 r = ROOT.TFile.Open("SimpleShapes_" + binName + ".root", "read")
-h = r.Get("data_obs_" + binName)
+h = r.Get("data_obs_" + binName + "_")
 observed = h.Integral()
 f.write("observation " + str(observed) + "\n")
 f.write("----------\n")

--- a/CombineMacros/CombineControl.py
+++ b/CombineMacros/CombineControl.py
@@ -45,7 +45,7 @@ f.write("imax " + str(1) + "\n") #number of channels
 f.write("jmax " + str(len(bgrNames)) + "\n") #number of backgrounds
 f.write("kmax " + str(len(systNames)) + "\n") #number of nuisance parameters
 f.write("----------\n")
-f.write("shapes * * SimpleShapes_" + binName + ".root $PROCESS_$CHANNEL $PROCESS_$CHANNEL_$SYSTEMATIC\n")
+f.write("shapes * * SimpleShapes_" + binName + ".root $PROCESS_$CHANNEL_ $PROCESS_$CHANNEL_$SYSTEMATIC\n")
 f.write("----------\n")
 f.write("bin         " + binName + "\n")
 

--- a/CombineMacros/CombineHistogramDumpster.C
+++ b/CombineMacros/CombineHistogramDumpster.C
@@ -34,6 +34,17 @@ void CombineHistogramDumpster::Loop()
   TString binS = TString::Format("Wprime%d", bin);
   TString gn = dset.GroupName;
 
+  //set sample weight
+  int Year = 0;
+  int year = 0;
+  float Lumi = 0.;
+  if(YearType == "2016_APV")  {Year = 0; year = 2016; Lumi = 0.;}
+  else if(YearType == "2016") {Year = 1; year = 2016; Lumi = 41.58;}
+  else if(YearType == "2017") {Year = 2; year = 2017; Lumi = 49.81;}
+  else if(YearType == "2018") {Year = 3; year = 2018; Lumi = 67.86;}
+  float SampleWeight = 1.;
+  if(dset.Type != 0) SampleWeight = Lumi * dset.CrossSection / dset.Size[Year];
+
   //define variations
   vector<TH1F*> WPrimeMass_FL;
 
@@ -41,7 +52,7 @@ void CombineHistogramDumpster::Loop()
   vector<TString> variations = {"" // 0
   , "electronScaleUp", "electronScaleDown", "electronResUp", "electronResDown", "JESUp", "JESDown", "JERUp", "JERDown" // 1 - 8
   , "electronUp", "electronDown", "muonTriggerUp", "muonTriggerDown", "muonIdUp", "muonIdDown", "muonIsoUp", "muonIsoDown" // 9 - 16
-  , "BjetTagCorrUp", "BjetTagCorrDown", "BjetTagUncorrUp", "BjetTagUncorrDown", "PUIDUp", "PUIDDown", "L1PreFiringUp", "L1PreFiringDown" // 17 - 24
+  , "BjetTagCorrUp", "BjetTagCorrDown", "BjetTagUncorrUp"+YearType, "BjetTagUncorrDown"+YearType, "PUIDUp", "PUIDDown", "L1PreFiringUp", "L1PreFiringDown" // 17 - 24
   , "PUreweightUp", "PUreweightDown", "PDFUp", "PDFDown", "LHEScaleUp", "LHEScaleDown", // 25 - 30
   };
 
@@ -62,7 +73,7 @@ void CombineHistogramDumpster::Loop()
   if(YearType == "2016_APV")  {Year = 0; year = 2016; Lumi = 0.;}
   else if(YearType == "2016") {Year = 1; year = 2016; Lumi = 41.58;}
   else if(YearType == "2017") {Year = 2; year = 2017; Lumi = 49.81;}
-  else if(YearType == "2018") {Year = 3; year = 2017; Lumi = 67.86;}
+  else if(YearType == "2018") {Year = 3; year = 2018; Lumi = 67.86;}
   float SampleWeight = 1.;
   if(dset.Type != 0) SampleWeight = Lumi * dset.CrossSection / dset.Size[Year];
 
@@ -87,7 +98,7 @@ void CombineHistogramDumpster::Loop()
       //EventWeight variations
       for(unsigned i = 9; i < variations.size(); ++i){
         string HistName;
-        WPrimeMass_FL[i]->Fill(WPrimeMassSimpleFL->at(0),EventWeight[i]*SampleWeight);
+        WPrimeMass_FL[i]->Fill(WPrimeMassSimpleFL->at(0),EventWeight[i-8]*SampleWeight);
       }
     }
     
@@ -102,7 +113,7 @@ void CombineHistogramDumpster::Loop()
   for(unsigned i = 0; i < WPrimeMass_FL.size(); ++i){
     if(dset.Type == 0){
       if(i>0) continue;
-      if(Iterator <= 1) WPrimeMass_FL[i]->Write("data_obs_" + binS);
+      if(Iterator <= 1) WPrimeMass_FL[i]->Write("data_obs_" + binS + "_");
       else continue;
     }
     else if(Iterator == 2 && SFreg != 0){ //case of applying SF to ttbar

--- a/CombineMacros/CombineHistogramDumpster.C
+++ b/CombineMacros/CombineHistogramDumpster.C
@@ -52,7 +52,7 @@ void CombineHistogramDumpster::Loop()
   vector<TString> variations = {"" // 0
   , "electronScaleUp", "electronScaleDown", "electronResUp", "electronResDown", "JESUp", "JESDown", "JERUp", "JERDown" // 1 - 8
   , "electronUp", "electronDown", "muonTriggerUp", "muonTriggerDown", "muonIdUp", "muonIdDown", "muonIsoUp", "muonIsoDown" // 9 - 16
-  , "BjetTagCorrUp", "BjetTagCorrDown", "BjetTagUncorrUp"+YearType, "BjetTagUncorrDown"+YearType, "PUIDUp", "PUIDDown", "L1PreFiringUp", "L1PreFiringDown" // 17 - 24
+  , "BjetTagCorrUp", "BjetTagCorrDown", "BjetTagUncorr"+YearType+"Up", "BjetTagUncorr"+YearType+"Down", "PUIDUp", "PUIDDown", "L1PreFiringUp", "L1PreFiringDown" // 17 - 24
   , "PUreweightUp", "PUreweightDown", "PDFUp", "PDFDown", "LHEScaleUp", "LHEScaleDown", // 25 - 30
   };
 
@@ -65,17 +65,6 @@ void CombineHistogramDumpster::Loop()
   if (fChain == 0) return;
 
   Long64_t nentries = fChain->GetEntriesFast();
-
-  //set sample weight
-  int Year = 0;
-  int year = 0;
-  float Lumi = 0.;
-  if(YearType == "2016_APV")  {Year = 0; year = 2016; Lumi = 0.;}
-  else if(YearType == "2016") {Year = 1; year = 2016; Lumi = 41.58;}
-  else if(YearType == "2017") {Year = 2; year = 2017; Lumi = 49.81;}
-  else if(YearType == "2018") {Year = 3; year = 2018; Lumi = 67.86;}
-  float SampleWeight = 1.;
-  if(dset.Type != 0) SampleWeight = Lumi * dset.CrossSection / dset.Size[Year];
 
   //loop over events
   Long64_t nbytes = 0, nb = 0;

--- a/CombineMacros/CombineHistogramDumpster.C
+++ b/CombineMacros/CombineHistogramDumpster.C
@@ -33,53 +33,22 @@ void CombineHistogramDumpster::Loop()
   //define bin for analysis
   TString binS = TString::Format("Wprime%d", bin);
   TString gn = dset.GroupName;
+
   //define variations
   vector<TH1F*> WPrimeMass_FL;
+
   //first variations are all weight variations and map 1:1, region variations start at index 21
   vector<TString> variations = {"" // 0
   , "electronScaleUp", "electronScaleDown", "electronResUp", "electronResDown", "JESUp", "JESDown", "JERUp", "JERDown" // 1 - 8
   , "electronUp", "electronDown", "muonTriggerUp", "muonTriggerDown", "muonIdUp", "muonIdDown", "muonIsoUp", "muonIsoDown" // 9 - 16
   , "BjetTagCorrUp", "BjetTagCorrDown", "BjetTagUncorrUp", "BjetTagUncorrDown", "PUIDUp", "PUIDDown", "L1PreFiringUp", "L1PreFiringDown" // 17 - 24
   , "PUreweightUp", "PUreweightDown", "PDFUp", "PDFDown", "LHEScaleUp", "LHEScaleDown", // 25 - 30
-
   };
-  for (unsigned i = 1; i < variations.size(); ++i) {
+
+  for (unsigned i = 0; i < variations.size(); ++i) {
     variations[i] = gn + "_" + binS + "_" + variations[i];
   }
 
-  // vector<TString> variations = {
-  //   gn + "_" + binS,                             // 0
-  //   gn + "_" + binS + "_" + "electronUp",        // 1
-  //   gn + "_" + binS + "_" + "electronDown",      // 2
-	// 	gn + "_" + binS + "_" + "muonTriggerUp",     // 3
-	// 	gn + "_" + binS + "_" + "muonTriggerDown",   // 4
-	// 	gn + "_" + binS + "_" + "muonIdUp",          // 5
-	// 	gn + "_" + binS + "_" + "muonIdDown",        // 6
-	// 	gn + "_" + binS + "_" + "muonIsoUp",         // 7
-	// 	gn + "_" + binS + "_" + "muonIsoDown",       // 8
-	// 	gn + "_" + binS + "_" + "BjetTagCorrUp",     // 9
-	// 	gn + "_" + binS + "_" + "BjetTagCorrDown",   // 10
-  //   gn + "_" + binS + "_" + "BjetTagUncorrUp",   // 11
-	// 	gn + "_" + binS + "_" + "BjetTagUncorrDown", // 12
-	// 	gn + "_" + binS + "_" + "PUIDUp",            // 13
-	// 	gn + "_" + binS + "_" + "PUIDDown",          // 14
-	// 	gn + "_" + binS + "_" + "L1PreFiringUp",     // 15
-	// 	gn + "_" + binS + "_" + "L1PreFiringDown",
-	// 	gn + "_" + binS + "_" + "PUreweightUp",
-	// 	gn + "_" + binS + "_" + "PUreweightDown",
-	// 	gn + "_" + binS + "_" + "PDFUp",
-	// 	gn + "_" + binS + "_" + "PDFDown",
-	// 	gn + "_" + binS + "_" + "LHEScaleUp",
-	// 	gn + "_" + binS + "_" + "LHEScaleDown",
-	// 	gn + "_" + binS + "_" + "electronScaleUp",
-	// 	gn + "_" + binS + "_" + "electronScaleDown",
-	// 	gn + "_" + binS + "_" + "electronResUp",
-	// 	gn + "_" + binS + "_" + "electronResDown",
-	// 	gn + "_" + binS + "_" + "JESUp",
-	// 	gn + "_" + binS + "_" + "JESDown",
-	// 	gn + "_" + binS + "_" + "JERUp",
-	// 	gn + "_" + binS + "_" + "JERDown"
-  // };
   for(unsigned i = 0; i < variations.size(); ++i) WPrimeMass_FL.push_back(new TH1F(variations[i],"W' mass, simplified, FL case; m_{W'} [GeV/c^{2}]; Events", 400, 0., 2000.));
 
   if (fChain == 0) return;
@@ -121,12 +90,12 @@ void CombineHistogramDumpster::Loop()
   TFile *savefile;
   //if(!Iterator) savefile = new TFile("TestHistograms/SimpleShapes.root","RECREATE");
   //else savefile = new TFile("TestHistograms/SimpleShapes.root","WRITE");
-  savefile = new TFile(TString::Format("TestHistograms/SimpleShapes%d.root",Iterator),"RECREATE");
+  savefile = new TFile(TString::Format("TestHistograms/SimpleShapes_Bin%d_%d.root",bin,Iterator),"RECREATE");
   savefile->cd();
   for(unsigned i = 0; i < WPrimeMass_FL.size(); ++i){
     if(dset.Type == 0){
       if(i>0) continue;
-      if(Iterator == 1) WPrimeMass_FL[i]->Write("data_obs_" + binS);
+      if(Iterator <= 1) WPrimeMass_FL[i]->Write("data_obs_" + binS);
       else continue;
     }
     else WPrimeMass_FL[i]->Write(WPrimeMass_FL[i]->GetName());

--- a/CombineMacros/CombineHistogramDumpster.h
+++ b/CombineMacros/CombineHistogramDumpster.h
@@ -18,35 +18,41 @@
 
 class CombineHistogramDumpster {
 public :
-  TTree          *fChain;   //!pointer to the analyzed TTree or TChain
+  TChain          *fChain;   //!pointer to the analyzed TTree or TChain
   Int_t           fCurrent; //!current Tree number in a TChain
 
   // Fixed size dimensions of array or collections stored in the TTree if any.
 
   // Declaration of leaf types
   Int_t           RegionIdentifier[9];
-  Float_t         EventWeight[21];
+  Float_t         EventWeight[23];
   Float_t         LeptonPt;
   Float_t         LeptonPt_SU;
   Float_t         LeptonPt_SD;
   Float_t         LeptonPt_RU;
   Float_t         LeptonPt_RD;
   Float_t         LeptonEta;
+  Float_t	  LeptonPhi;
   vector<float>   *JetPt;
   vector<float>   *JetPt_SU;
   vector<float>   *JetPt_SD;
   vector<float>   *JetPt_RU;
   vector<float>   *JetPt_RD;
   vector<float>   *JetEta;
+  vector<float>   *JetPhi;
   Float_t         METPt;
   Float_t         METPt_SU;
   Float_t         METPt_SD;
   Float_t         METPt_RU;
   Float_t         METPt_RD;
   Float_t         METPhi;
+  Float_t	  dPhiMetLep;
   vector<float>   *mT;
   vector<float>   *WPrimeMassSimpleFL;
   vector<float>   *WPrimeMassSimpleLL;
+  vector<float>   *WPrimeMass;
+  vector<float>   *Likelihood;
+  vector<int>     *WPType;
   Int_t           nPU;
   Float_t         nTrueInt;
   Int_t           nPV;
@@ -61,32 +67,38 @@ public :
   TBranch        *b_LeptonPt_RU;   //!
   TBranch        *b_LeptonPt_RD;   //!
   TBranch        *b_LeptonEta;   //!
+  TBranch        *b_LeptonPhi;   //!
   TBranch        *b_JetPt;   //!
   TBranch        *b_JetPt_SU;   //!
   TBranch        *b_JetPt_SD;   //!
   TBranch        *b_JetPt_RU;   //!
   TBranch        *b_JetPt_RD;   //!
   TBranch        *b_JetEta;   //!
+  TBranch	 *b_JetPhi;  //!
   TBranch        *b_METPt;   //!
   TBranch        *b_METPt_SU;   //!
   TBranch        *b_METPt_SD;   //!
   TBranch        *b_METPt_RU;   //!
   TBranch        *b_METPt_RD;   //!
   TBranch        *b_METPhi;   //!
+  TBranch	 *b_dPhiMetLep; //!
   TBranch        *b_mT;   //!
   TBranch        *b_WPrimeMassSimpleFL;   //!
   TBranch        *b_WPrimeMassSimpleLL;   //!
+  TBranch	 *b_WPrimeMass; //!
+  TBranch	 *b_Likelihood; //!
+  TBranch	 *b_WPType; //!
   TBranch        *b_nPU;   //!
   TBranch        *b_nTrueInt;   //!
   TBranch        *b_nPV;   //!
   TBranch        *b_nPVGood;   //!
 
-  CombineHistogramDumpster(TTree *tree = 0, unsigned it_ = 99, int bin_ = 1152, TString year_ = "2018");
+  CombineHistogramDumpster(TChain *tree = 0, unsigned it_ = 99, int bin_ = 1152, TString year_ = "2018", bool ScaleTtbar_ = false);
   virtual ~CombineHistogramDumpster();
   virtual Int_t    Cut(Long64_t entry);
   virtual Int_t    GetEntry(Long64_t entry);
   virtual Long64_t LoadTree(Long64_t entry);
-  virtual void     Init(TTree *tree);
+  virtual void     Init(TChain *tree);
   virtual void     Loop();
   virtual Bool_t   Notify();
   virtual void     Show(Long64_t entry = -1);
@@ -95,12 +107,13 @@ public :
   string YearType;
   Dataset dset;
   int bin;
+  bool ScaleTtbar;
 };
 
 #endif
 
 #ifdef CombineHistogramDumpster_cxx
-CombineHistogramDumpster::CombineHistogramDumpster(TTree *tree, unsigned it_, int bin_, TString year_) : fChain(0) 
+CombineHistogramDumpster::CombineHistogramDumpster(TChain *tree, unsigned it_, int bin_, TString year_, bool ScaleTtbar_) : fChain(0) 
 {
   if(it_>39) {
     std::cout<<"iterator out of range"<<std::endl;
@@ -110,16 +123,13 @@ CombineHistogramDumpster::CombineHistogramDumpster(TTree *tree, unsigned it_, in
 // used to generate this class and read the Tree.
   if (tree == 0) {
     dset = dlib.GetDataset(it_);
-    TString FilePath = "/eos/user/s/siluo/WPrimeAnalysis/Validation/" + year_ + "_" + dset.Name + ".root";
-    TFile *f = new TFile(FilePath,"READ");
-    if (!f || !f->IsOpen()) {
-      std::cout<<"Failed to find File"<<std::endl;
-      return;
-    }
-    f->GetObject("t",tree);
+    TString FilePath = "/eos/user/s/siluo/WPrimeAnalysis/Validation/" + year_ + "_" + dset.Name + "/*.root";
+    tree = new TChain("t");
+    tree->Add(FilePath);
     Iterator = it_;
     YearType = year_;
     bin = bin_;
+    ScaleTtbar_;
   }
   Init(tree);
 }
@@ -149,7 +159,7 @@ Long64_t CombineHistogramDumpster::LoadTree(Long64_t entry)
   return centry;
 }
 
-void CombineHistogramDumpster::Init(TTree *tree)
+void CombineHistogramDumpster::Init(TChain *tree)
 {
   // The Init() function is called when the selector needs to initialize
   // a new tree or chain. Typically here the branch addresses and branch
@@ -166,9 +176,13 @@ void CombineHistogramDumpster::Init(TTree *tree)
   JetPt_RU = 0;
   JetPt_RD = 0;
   JetEta = 0;
+  JetPhi = 0;
   mT = 0;
   WPrimeMassSimpleFL = 0;
   WPrimeMassSimpleLL = 0;
+  WPrimeMass = 0;
+  Likelihood = 0;
+  WPType = 0;
   // Set branch addresses and branch pointers
   if (!tree) return;
   fChain = tree;
@@ -183,21 +197,27 @@ void CombineHistogramDumpster::Init(TTree *tree)
   fChain->SetBranchAddress("LeptonPt_RU", &LeptonPt_RU, &b_LeptonPt_RU);
   fChain->SetBranchAddress("LeptonPt_RD", &LeptonPt_RD, &b_LeptonPt_RD);
   fChain->SetBranchAddress("LeptonEta", &LeptonEta, &b_LeptonEta);
+  fChain->SetBranchAddress("LeptonPhi", &LeptonPhi, &b_LeptonPhi);
   fChain->SetBranchAddress("JetPt", &JetPt, &b_JetPt);
   fChain->SetBranchAddress("JetPt_SU", &JetPt_SU, &b_JetPt_SU);
   fChain->SetBranchAddress("JetPt_SD", &JetPt_SD, &b_JetPt_SD);
   fChain->SetBranchAddress("JetPt_RU", &JetPt_RU, &b_JetPt_RU);
   fChain->SetBranchAddress("JetPt_RD", &JetPt_RD, &b_JetPt_RD);
   fChain->SetBranchAddress("JetEta", &JetEta, &b_JetEta);
+  fChain->SetBranchAddress("JetPhi", &JetPhi, &b_JetPhi);
   fChain->SetBranchAddress("METPt", &METPt, &b_METPt);
   fChain->SetBranchAddress("METPt_SU", &METPt_SU, &b_METPt_SU);
   fChain->SetBranchAddress("METPt_SD", &METPt_SD, &b_METPt_SD);
   fChain->SetBranchAddress("METPt_RU", &METPt_RU, &b_METPt_RU);
   fChain->SetBranchAddress("METPt_RD", &METPt_RD, &b_METPt_RD);
   fChain->SetBranchAddress("METPhi", &METPhi, &b_METPhi);
+  fChain->SetBranchAddress("dPhiMetLep", &dPhiMetLep, &b_dPhiMetLep);
   fChain->SetBranchAddress("mT", &mT, &b_mT);
   fChain->SetBranchAddress("WPrimeMassSimpleFL", &WPrimeMassSimpleFL, &b_WPrimeMassSimpleFL);
   fChain->SetBranchAddress("WPrimeMassSimpleLL", &WPrimeMassSimpleLL, &b_WPrimeMassSimpleLL);
+  fChain->SetBranchAddress("WPrimeMass", &WPrimeMass, &b_WPrimeMass);
+  fChain->SetBranchAddress("Likelihood", &Likelihood, &b_Likelihood);
+  fChain->SetBranchAddress("WPType", &WPType, &b_WPType);
   fChain->SetBranchAddress("nPU", &nPU, &b_nPU);
   fChain->SetBranchAddress("nTrueInt", &nTrueInt, &b_nTrueInt);
   fChain->SetBranchAddress("nPV", &nPV, &b_nPV);

--- a/CombineMacros/CombineHistogramDumpster.h
+++ b/CombineMacros/CombineHistogramDumpster.h
@@ -93,7 +93,7 @@ public :
   TBranch        *b_nPV;   //!
   TBranch        *b_nPVGood;   //!
 
-  CombineHistogramDumpster(TChain *tree = 0, unsigned it_ = 99, int bin_ = 1152, TString year_ = "2018", bool ScaleTtbar_ = false);
+  CombineHistogramDumpster(TChain *tree = 0, unsigned it_ = 99, int bin_ = 1152, TString year_ = "2018", int SFreg_ = 0);
   virtual ~CombineHistogramDumpster();
   virtual Int_t    Cut(Long64_t entry);
   virtual Int_t    GetEntry(Long64_t entry);
@@ -107,13 +107,13 @@ public :
   string YearType;
   Dataset dset;
   int bin;
-  bool ScaleTtbar;
+  int SFreg;
 };
 
 #endif
 
 #ifdef CombineHistogramDumpster_cxx
-CombineHistogramDumpster::CombineHistogramDumpster(TChain *tree, unsigned it_, int bin_, TString year_, bool ScaleTtbar_) : fChain(0) 
+CombineHistogramDumpster::CombineHistogramDumpster(TChain *tree, unsigned it_, int bin_, TString year_, int SFreg_) : fChain(0) 
 {
   if(it_>39) {
     std::cout<<"iterator out of range"<<std::endl;
@@ -129,7 +129,7 @@ CombineHistogramDumpster::CombineHistogramDumpster(TChain *tree, unsigned it_, i
     Iterator = it_;
     YearType = year_;
     bin = bin_;
-    ScaleTtbar_;
+    SFreg = SFreg_;
   }
   Init(tree);
 }

--- a/CombineMacros/ScaleFactorTTbarCalc.C
+++ b/CombineMacros/ScaleFactorTTbarCalc.C
@@ -11,11 +11,13 @@
 
 //derive ttbar SF from 2-tag regions of same multiplicity and lepton flavour, then propagate stat uncertainty envelope bin-by-bin and do syst variation histograms
 void ScaleFactorTTbarCalc(int bin=1152, int year=2018){
-  
+ 
+  TString sYear = TString::Format("%d",year);
+ 
   vector<TString> variations = {"" // 0
     , "electronScaleUp", "electronScaleDown", "electronResUp", "electronResDown", "JESUp", "JESDown", "JERUp", "JERDown" // 1 - 8
     , "electronUp", "electronDown", "muonTriggerUp", "muonTriggerDown", "muonIdUp", "muonIdDown", "muonIsoUp", "muonIsoDown" // 9 - 16
-    , "BjetTagCorrUp", "BjetTagCorrDown", "BjetTagUncorrUp", "BjetTagUncorrDown", "PUIDUp", "PUIDDown", "L1PreFiringUp", "L1PreFiringDown" // 17 - 24
+    , "BjetTagCorrUp", "BjetTagCorrDown", "BjetTagUncorr"+sYear+ "Up", "BjetTagUncorr"+sYear+ "Down", "PUIDUp", "PUIDDown", "L1PreFiringUp", "L1PreFiringDown" // 17 - 24
     , "PUreweightUp", "PUreweightDown", "PDFUp", "PDFDown", "LHEScaleUp", "LHEScaleDown", // 25 - 30
   };
 
@@ -29,7 +31,7 @@ void ScaleFactorTTbarCalc(int bin=1152, int year=2018){
     TFile *infile = new TFile(TString::Format("TestHistograms/SimpleShapes_Bin%d_%d.root",bin,i),"READ");
     Dataset dset = dlib.GetDataset(i);
     TString gn = dset.GroupName;
-    if(i<=1) dataHist = *(TH1F*)(infile->Get(TString::Format("data_obs_Wprime%d",bin)))->Clone("dataHist");
+    if(i<=1) dataHist = *(TH1F*)(infile->Get(TString::Format("data_obs_Wprime%d_",bin)))->Clone("dataHist");
     else if(i==2){
       for(unsigned j = 0; j < variations.size(); ++j) ttbarHists.push_back(*(TH1F*)(infile->Get(TString::Format(gn+"_Wprime%d_"+variations[j],bin)))->Clone(TString::Format("ttbar_%d",j)));
     }
@@ -64,7 +66,6 @@ void ScaleFactorTTbarCalc(int bin=1152, int year=2018){
     float Deriv3 = 1.;
     float FinalEnvelope = 0.;
     //scan covariance matrix
-    std::cout<<"_____"<<bc<<"_____"<<std::endl;
     for(unsigned x = 0; x < 4; ++x){
       for(unsigned y = 0; y < 4; ++y){
         float Component = 1.;
@@ -76,11 +77,8 @@ void ScaleFactorTTbarCalc(int bin=1152, int year=2018){
         else if (y == 1) Component *= Deriv1;
         else if (y == 2) Component *= Deriv2;
         else if (y == 3) Component *= Deriv3;
-	std::cout<<Component<<std::endl;
 	Component *= cov(x,y);
-	std::cout<<Component<<std::endl;
 	FinalEnvelope += Component;
-	std::cout<<"-----"<<FinalEnvelope<<"-----"<<std::endl;
       }
     }
     SFs[0].SetBinContent(i+1, fitFunction->Eval(bc));

--- a/CombineMacros/ScaleFactorTTbarCalc.C
+++ b/CombineMacros/ScaleFactorTTbarCalc.C
@@ -1,0 +1,104 @@
+#include <TROOT.h>
+#include "../Utilities/Dataset.cc"
+#include <TFile.h>
+#include <TF1.h>
+#include <TH1.h>
+#include <vector>
+#include <TString.h>
+#include <TFitResult.h> 
+#include <TMatrixD.h>
+#include <TMath.h>
+
+//derive ttbar SF from 2-tag regions of same multiplicity and lepton flavour, then propagate stat uncertainty envelope bin-by-bin and do syst variation histograms
+void ScaleFactorTTbarCalc(int bin=1152, int year=2018){
+  
+  vector<TString> variations = {"" // 0
+    , "electronScaleUp", "electronScaleDown", "electronResUp", "electronResDown", "JESUp", "JESDown", "JERUp", "JERDown" // 1 - 8
+    , "electronUp", "electronDown", "muonTriggerUp", "muonTriggerDown", "muonIdUp", "muonIdDown", "muonIsoUp", "muonIsoDown" // 9 - 16
+    , "BjetTagCorrUp", "BjetTagCorrDown", "BjetTagUncorrUp", "BjetTagUncorrDown", "PUIDUp", "PUIDDown", "L1PreFiringUp", "L1PreFiringDown" // 17 - 24
+    , "PUreweightUp", "PUreweightDown", "PDFUp", "PDFDown", "LHEScaleUp", "LHEScaleDown", // 25 - 30
+  };
+
+  TH1F dataHist;
+  vector<TH1F> ttbarHists, NonTtbarHists;
+
+  //loop over samples, organizing data, ttbar, and non-ttbar with variations
+  for(unsigned i = 0; i < 40; ++i){
+    if(bin/1000 == 1 && i == 0) continue;
+    if(bin/2000 == 1 && i == 1) continue;
+    TFile *infile = new TFile(TString::Format("TestHistograms/SimpleShapes_Bin%d_%d.root",bin,i),"READ");
+    Dataset dset = dlib.GetDataset(i);
+    TString gn = dset.GroupName;
+    if(i<=1) dataHist = *(TH1F*)(infile->Get(TString::Format("data_obs_Wprime%d",bin)))->Clone("dataHist");
+    else if(i==2){
+      for(unsigned j = 0; j < variations.size(); ++j) ttbarHists.push_back(*(TH1F*)(infile->Get(TString::Format(gn+"_Wprime%d_"+variations[j],bin)))->Clone(TString::Format("ttbar_%d",j)));
+    }
+   else if (i==3){
+     for(unsigned j = 0; j < variations.size(); ++j) NonTtbarHists.push_back(*(TH1F*)(infile->Get(TString::Format(gn+"_Wprime%d_"+variations[j],bin)))->Clone(TString::Format("nonTtbar_%d",j)));
+   }
+   else{
+     for(unsigned j = 0; j < variations.size(); ++j) NonTtbarHists[j].Add((TH1F*)(infile->Get(TString::Format(gn+"_Wprime%d_"+variations[j],bin))));
+   }
+  }
+
+  //use variations gathered to calculate central SF histogram and variation SF histograms
+  vector<TH1F> SFhists, SFs;
+  for(unsigned i = 0; i < variations.size(); ++i){
+    SFhists.push_back(*(TH1F*)dataHist.Clone("SF_"+variations[i]));
+    SFhists[i].Add(&NonTtbarHists[i],-1.);
+    SFhists[i].Divide(&ttbarHists[i]);
+    SFs.push_back(*(TH1F*)SFhists[i].Clone("SFcalc_"+variations[i]));
+  }
+
+  //define fit function
+  TF1 *fitFunction = new TF1("fitFunction","[0]/x+[1]*x+[2]*x*x+[3]", 150., 2000.);
+
+  //fit nominal variant with statistical uncertainties only, get covariance matrix, calculate statistical envelope
+  TFitResultPtr fr = SFhists[0].Fit(fitFunction,"SRF");
+  TMatrixD cov = fr->GetCovarianceMatrix();
+  for(unsigned i = 0; i < SFhists[0].GetNbinsX(); ++i){
+    float bc = SFhists[0].GetBinCenter(i+1);
+    float Deriv0 = 1./bc;
+    float Deriv1 = bc;
+    float Deriv2 = bc*bc;
+    float Deriv3 = 1.;
+    float FinalEnvelope = 0.;
+    //scan covariance matrix
+    std::cout<<"_____"<<bc<<"_____"<<std::endl;
+    for(unsigned x = 0; x < 4; ++x){
+      for(unsigned y = 0; y < 4; ++y){
+        float Component = 1.;
+        if(x == 0) Component *= Deriv0;
+        else if (x == 1) Component *= Deriv1;
+        else if (x == 2) Component *= Deriv2;
+        else if (x == 3) Component *= Deriv3;
+        if(y == 0) Component *= Deriv0;
+        else if (y == 1) Component *= Deriv1;
+        else if (y == 2) Component *= Deriv2;
+        else if (y == 3) Component *= Deriv3;
+	std::cout<<Component<<std::endl;
+	Component *= cov(x,y);
+	std::cout<<Component<<std::endl;
+	FinalEnvelope += Component;
+	std::cout<<"-----"<<FinalEnvelope<<"-----"<<std::endl;
+      }
+    }
+    SFs[0].SetBinContent(i+1, fitFunction->Eval(bc));
+    SFs[0].SetBinError(i+1, TMath::Sqrt(FinalEnvelope));
+  }
+
+  //fit systematic variations
+  for(unsigned i = 1; i < SFhists.size(); ++i){
+    SFhists[i].Fit(fitFunction,"R");
+    for(unsigned j = 0; j < SFhists[i].GetNbinsX(); ++j){
+      SFs[i].SetBinContent(j+1, fitFunction->Eval(SFhists[i].GetBinCenter(j+1)));
+      SFs[i].SetBinError(j+1, 0.);
+    }
+  }
+
+  TFile *savefile = new TFile(TString::Format("TestHistograms/SF_Bin%d_%d.root",bin,year),"RECREATE");
+  for(unsigned i = 0; i < SFhists.size(); ++i){
+    SFhists[i].Write();
+    SFs[i].Write();
+  }
+} 

--- a/CombineMacros/runCombineHistogramDumpster.C
+++ b/CombineMacros/runCombineHistogramDumpster.C
@@ -1,10 +1,24 @@
 #include "CombineHistogramDumpster.C"
+//#include "ScaleFactorTTbarCalc.C"
 
-void runCombineHistogramDumpster(int bin = 1152, int year = 2018){
+void runCombineHistogramDumpster(int bin = 1153, int year = 2018){
+  //first run CR for SF calculation
+  int binCR = 0;
+  if(bin/1000 == 1) binCR+=1100;
+  else if(bin/2000 == 1) binCR+=2100;
+  if((bin-binCR)/60 == 1) binCR+=62;
+  else binCR+=52;
   for(unsigned i = 0; i < 40; ++i){
     if(bin/1000 == 1 && i == 0) continue;
     else if(bin/2000 == 1 && i == 1) continue;
-    CombineHistogramDumpster D(0, i, bin, TString::Format("%d", year)); //don't supply a year, for now, there are no options
+    CombineHistogramDumpster D(0, i, binCR, TString::Format("%d", year), false);
     D.Loop();
   }
+  //run actual variations and SF'd ttbar
+  /*for(unsigned i = 0; i < 40; ++i){
+    if(bin/1000 == 1 && i == 0) continue;
+    else if(bin/2000 == 1 && i == 1) continue;
+    CombineHistogramDumpster D(0, i, bin, TString::Format("%d", year), true); //don't supply a year, for now, there are no options
+    D.Loop();
+  }*/
 }

--- a/CombineMacros/runCombineHistogramDumpster.C
+++ b/CombineMacros/runCombineHistogramDumpster.C
@@ -1,5 +1,5 @@
 #include "CombineHistogramDumpster.C"
-//#include "ScaleFactorTTbarCalc.C"
+#include "ScaleFactorTTbarCalc.C"
 
 void runCombineHistogramDumpster(int bin = 1153, int year = 2018){
   //first run CR for SF calculation
@@ -11,14 +11,18 @@ void runCombineHistogramDumpster(int bin = 1153, int year = 2018){
   for(unsigned i = 0; i < 40; ++i){
     if(bin/1000 == 1 && i == 0) continue;
     else if(bin/2000 == 1 && i == 1) continue;
-    CombineHistogramDumpster D(0, i, binCR, TString::Format("%d", year), false);
+    CombineHistogramDumpster D(0, i, binCR, TString::Format("%d", year), 0);
     D.Loop();
   }
+
+  //fit SFs and variations
+  ScaleFactorTTbarCalc(binCR, year);
+
   //run actual variations and SF'd ttbar
-  /*for(unsigned i = 0; i < 40; ++i){
+  for(unsigned i = 0; i < 40; ++i){
     if(bin/1000 == 1 && i == 0) continue;
     else if(bin/2000 == 1 && i == 1) continue;
-    CombineHistogramDumpster D(0, i, bin, TString::Format("%d", year), true); //don't supply a year, for now, there are no options
+    CombineHistogramDumpster D(0, i, bin, TString::Format("%d", year), binCR); //don't supply a year, for now, there are no options
     D.Loop();
-  }*/
+  }
 }

--- a/CombineMacros/runCombineHistogramDumpster.C
+++ b/CombineMacros/runCombineHistogramDumpster.C
@@ -8,7 +8,7 @@ void runCombineHistogramDumpster(int bin = 1153, int year = 2018){
   else if(bin/2000 == 1) binCR+=2100;
   if((bin-binCR)/60 == 1) binCR+=62;
   else binCR+=52;
-  for(unsigned i = 0; i < 40; ++i){
+  for(unsigned i = 0; i < 22; ++i){//skip signal samples
     if(bin/1000 == 1 && i == 0) continue;
     else if(bin/2000 == 1 && i == 1) continue;
     CombineHistogramDumpster D(0, i, binCR, TString::Format("%d", year), 0);

--- a/Utilities/NanoAODReader.cc
+++ b/Utilities/NanoAODReader.cc
@@ -482,49 +482,9 @@ public:
       //set SF and variation for primary only, HEEP as in https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammaRunIIRecommendations#HEEPV7_0
       tmp.SFs = {1., 1., 1.};
       if(PassPrimary(tmp,0) && IsMC){
-        // FIXME!!!:
-        // If nominal is not primary, the lepton will not have scale factors?
-        // As we are accepting single veto lepton event and primary alone with random number of loose leptons.
-        if(fabs(tmp.Eta()) < 1.4442){
-          if(conf->SampleYear == "2016" || conf->SampleYear == "2016apv"){
-            tmp.SFs[0] = 0.983;
-            float unc = tmp.Et() < 90 ? 0.01 : min(1 + (tmp.Et() - 90) * 0.0022, 0.03);
-            tmp.SFs[1] = 0.983 + unc;
-            tmp.SFs[2] = 0.983 - unc;
-          }
-          else if(conf->SampleYear == "2017"){
-            tmp.SFs[0] = 0.968;
-            float unc = tmp.Et() < 90 ? 0.01 : min(1 + (tmp.Et() - 90) * 0.0022, 0.03);
-            tmp.SFs[1] = 0.968 + unc;
-            tmp.SFs[2] = 0.968 - unc;
-          }
-          else if(conf->SampleYear == "2018"){
-            tmp.SFs[0] = 0.969;
-            float unc = tmp.Et() < 90 ? 0.01 : min(1 + (tmp.Et() - 90) * 0.0022, 0.03);
-            tmp.SFs[1] = 0.969 + unc;
-            tmp.SFs[2] = 0.969 - unc;
-          }
-        }
-        else{
-          if(conf->SampleYear == "2016" || conf->SampleYear == "2016apv"){
-            tmp.SFs[0] = 0.991;
-            float unc = tmp.Et() < 90 ? 0.01 : min(1 + (tmp.Et() - 90) * 0.0143, 0.04);
-            tmp.SFs[1] = 0.991 + unc;
-            tmp.SFs[2] = 0.991 - unc;
-          }
-          else if(conf->SampleYear == "2017"){
-            tmp.SFs[0] = 0.973;
-            float unc = tmp.Et() < 90 ? 0.02 : min(1 + (tmp.Et() - 90) * 0.0143, 0.05);
-            tmp.SFs[1] = 0.973 + unc;
-            tmp.SFs[2] = 0.973 - unc;
-          }
-          else if(conf->SampleYear == "2018"){
-            tmp.SFs[0] = 0.984;
-            float unc = tmp.Et() < 90 ? 0.02 : min(1 + (tmp.Et() - 90) * 0.0143, 0.05);
-            tmp.SFs[1] = 0.984 + unc;
-            tmp.SFs[2] = 0.984 - unc;
-          }
-        }
+	tmp.SF[0] = evts->Electron_scaleFactor[i];
+	tmp.SF[1] = evts->Electron_scaleFactorUp[i];
+	tmp.SF[2] = evts->Electron_scaleFactorDown[i];
       }
 
       Electrons.push_back(tmp);


### PR DESCRIPTION
HEEP SFs removed, replaced with skim-based electron MVA ID SFs that is now primary.
A SF fitter from 2-tag to >2 tags has been added. The fitter calculates the statistical envelope of the fit function and propagates this to the ttbar estimate. It also refits systematic variations and treats this as systematic variations to the ttbar histograms.
The Combine card function has been updated to deal with this, hopefully appropriately.
New luminosity correlated and uncorrelated matrix per year have been included.
Blinding on card production level is enforced.

PDF uncertainty is known to be far too large. Needs further investigation. The NanoAODReader implementation looks good, so we have to look at the skims and the bare NanoAOD again...